### PR TITLE
Setter for block_sizes and a new method for getting a reduced representation of the sparse object

### DIFF
--- a/src/qttools/datastructures/dsbsparse.py
+++ b/src/qttools/datastructures/dsbsparse.py
@@ -179,12 +179,12 @@ class DSBSparse(ABC):
         self.block_offsets = xp.hstack(([0], xp.cumsum(self.block_sizes)))
         self.num_blocks = len(block_sizes)
         self.return_dense = return_dense
-    
+
     @property
     def block_sizes(self) -> ArrayLike:
         """Returns the block sizes."""
         return self._block_sizes
-    
+
     @block_sizes.setter
     @abstractmethod
     def block_sizes(self, block_sizes: ArrayLike) -> None:

--- a/src/qttools/datastructures/dsbsparse.py
+++ b/src/qttools/datastructures/dsbsparse.py
@@ -175,10 +175,21 @@ class DSBSparse(ABC):
         self.nnz = data.shape[-1]
         self.shape = self.stack_shape + (int(sum(block_sizes)), int(sum(block_sizes)))
 
-        self.block_sizes = xp.asarray(block_sizes).astype(int)
+        self._block_sizes = xp.asarray(block_sizes).astype(int)
         self.block_offsets = xp.hstack(([0], xp.cumsum(self.block_sizes)))
         self.num_blocks = len(block_sizes)
         self.return_dense = return_dense
+    
+    @property
+    def block_sizes(self) -> ArrayLike:
+        """Returns the block sizes."""
+        return self._block_sizes
+    
+    @block_sizes.setter
+    @abstractmethod
+    def block_sizes(self, block_sizes: ArrayLike) -> None:
+        """Sets the block sizes."""
+        ...
 
     def _normalize_index(self, index: tuple) -> tuple:
         """Adjusts the sign to allow negative indices and checks bounds."""
@@ -229,7 +240,7 @@ class DSBSparse(ABC):
 
         This does not return a copy of the data, but a view. This is
         also why we do not need a setter method (one can just set
-        `.data` directly).
+        `._data` directly).
 
         """
         if self.distribution_state == "stack":

--- a/tests/datastructures/conftest.py
+++ b/tests/datastructures/conftest.py
@@ -43,6 +43,12 @@ STACK_INDICES = [
     pytest.param((Ellipsis,), id="ellipsis"),
 ]
 
+BLOCK_CHANGE_FACTORS = [
+    pytest.param(1.0, id="no-change"),
+    pytest.param(0.5, id="half-change"),
+    pytest.param(2.0, id="double-change"),
+]
+
 
 @pytest.fixture(params=BLOCK_SIZES, autouse=True)
 def block_sizes(request):
@@ -76,4 +82,9 @@ def global_stack_shape(request):
 
 @pytest.fixture(params=STACK_INDICES)
 def stack_index(request):
+    return request.param
+
+
+@pytest.fixture(params=BLOCK_CHANGE_FACTORS)
+def block_change_factor(request):
     return request.param


### PR DESCRIPTION
Added setter for block_sizes, which is used in the screened interaction calculation of quatrex when going to larger block_sizes. 

Another method is also added for the calculation of the GW self-energy. Because the buffer for W is larger than that for G, we have to reduce W to the same sparsity pattern as G. This is handled by the calc_reduce_to_mask and reduce_to methods.