### PR TITLE
Proposed fix for issue #60

### DIFF
--- a/src/qttools/datastructures/dsbcoo.py
+++ b/src/qttools/datastructures/dsbcoo.py
@@ -100,12 +100,9 @@ class DSBCOO(DSBSparse):
         data_stack = self.data[*stack_index]
 
         if self.distribution_state == "stack":
-            if len(inds) != rows.size:
-                arr = xp.zeros(data_stack.shape[:-1] + (rows.size,), dtype=self.dtype)
-                arr[..., value_inds] = data_stack[..., inds]
-                return xp.squeeze(arr)
-
-            return xp.squeeze(data_stack[..., inds])
+            arr = xp.zeros(data_stack.shape[:-1] + (rows.size,), dtype=self.dtype)
+            arr[..., value_inds] = data_stack[..., inds]
+            return xp.squeeze(arr)
 
         if len(inds) != rows.size:
             # We cannot know which rank is supposed to hold an element

--- a/src/qttools/datastructures/dsbcsr.py
+++ b/src/qttools/datastructures/dsbcsr.py
@@ -152,12 +152,9 @@ class DSBCSR(DSBSparse):
 
         data_stack = self.data[stack_index]
         if self.distribution_state == "stack":
-            if len(inds) != rows.size:
-                arr = xp.zeros(data_stack.shape[:-1] + (rows.size,), dtype=self.dtype)
-                arr[..., value_inds] = data_stack[..., inds]
-                return xp.squeeze(arr)
-
-            return xp.squeeze(data_stack[..., inds])
+            arr = xp.zeros(data_stack.shape[:-1] + (rows.size,), dtype=self.dtype)
+            arr[..., value_inds] = data_stack[..., inds]
+            return xp.squeeze(arr)
 
         if len(inds) != rows.size:
             # We cannot know which rank is supposed to hold an element

--- a/tests/datastructures/conftest.py
+++ b/tests/datastructures/conftest.py
@@ -37,6 +37,12 @@ GLOBAL_STACK_SHAPES = [
     pytest.param((9, 2, 4), id="3D-stack"),
 ]
 
+FACTORS = [
+    pytest.param(0.0, id="no-densify"),
+    pytest.param(0.5, id="half-densify"),
+    pytest.param(1.0, id="full-densify"),
+]
+
 STACK_INDICES = [
     pytest.param((5,), id="single"),
     pytest.param((slice(1, 4),), id="slice"),
@@ -72,6 +78,11 @@ def accessed_block(request):
 
 @pytest.fixture(params=ACCESSED_ELEMENTS)
 def accessed_element(request):
+    return request.param
+
+
+@pytest.fixture(params=FACTORS)
+def factor(request):
     return request.param
 
 

--- a/tests/datastructures/conftest.py
+++ b/tests/datastructures/conftest.py
@@ -37,10 +37,10 @@ GLOBAL_STACK_SHAPES = [
     pytest.param((9, 2, 4), id="3D-stack"),
 ]
 
-FACTORS = [
-    pytest.param(0.0, id="no-densify"),
-    pytest.param(0.5, id="half-densify"),
-    pytest.param(1.0, id="full-densify"),
+NUM_INDS = [
+    pytest.param(5, id="5-inds"),
+    pytest.param(10, id="10-inds"),
+    pytest.param(20, id="20-inds"),
 ]
 
 STACK_INDICES = [
@@ -81,8 +81,8 @@ def accessed_element(request):
     return request.param
 
 
-@pytest.fixture(params=FACTORS)
-def factor(request):
+@pytest.fixture(params=NUM_INDS)
+def num_inds(request):
     return request.param
 
 

--- a/tests/datastructures/test_dsbsparse.py
+++ b/tests/datastructures/test_dsbsparse.py
@@ -173,15 +173,15 @@ class TestAccess:
         reference = dense[..., *accessed_element]
         assert xp.allclose(reference, dsbsparse[accessed_element])
 
-    @pytest.mark.usefixtures("factor")
+    @pytest.mark.usefixtures("num_inds")
     def test_getitem_with_array(
         self,
         dsbsparse_type: DSBSparse,
         block_sizes: xp.ndarray,
         global_stack_shape: tuple,
-        factor: float,
+        num_inds: int,
     ):
-        """Tests that we can get elements from a DSBSparse matrix using an tuple with arrays of row and column indices."""
+        """Tests that we can get elements from a DSBSparse matrix using a tuple with arrays of row and column indices."""
         coo = _create_coo(block_sizes)
         dsbsparse = dsbsparse_type.from_sparray(
             coo,
@@ -190,7 +190,9 @@ class TestAccess:
         )
 
         indices = xp.random.randint(
-            0, coo.shape[-1], size=(2, int(coo.shape[-1] * factor))
+            0,
+            coo.shape[-1],
+            size=(2, num_inds),
         )
         indices = tuple(indices)
         reference_data = coo.tocsr()[indices]

--- a/tests/datastructures/test_dsbsparse.py
+++ b/tests/datastructures/test_dsbsparse.py
@@ -173,6 +173,34 @@ class TestAccess:
         reference = dense[..., *accessed_element]
         assert xp.allclose(reference, dsbsparse[accessed_element])
 
+    @pytest.mark.usefixtures("factor")
+    def test_getitem_with_array(
+        self,
+        dsbsparse_type: DSBSparse,
+        block_sizes: xp.ndarray,
+        global_stack_shape: tuple,
+        factor: float,
+    ):
+        """Tests that we can get elements from a DSBSparse matrix using an tuple with arrays of row and column indices."""
+        coo = _create_coo(block_sizes)
+        dsbsparse = dsbsparse_type.from_sparray(
+            coo,
+            block_sizes=block_sizes,
+            global_stack_shape=global_stack_shape,
+        )
+
+        indices = xp.random.randint(
+            0, coo.shape[-1], size=(2, int(coo.shape[-1] * factor))
+        )
+        indices = tuple(indices)
+        reference_data = coo.tocsr()[indices]
+        if not isinstance(reference_data, xp.ndarray):
+            reference_data = reference_data.toarray()
+        reference = xp.broadcast_to(
+            reference_data, global_stack_shape + reference_data.shape[1:]
+        )
+        assert xp.allclose(reference, dsbsparse[indices])
+
     @pytest.mark.usefixtures("accessed_element")
     def test_setitem(
         self,


### PR DESCRIPTION
Always use the value_inds, incase rows and cols have different ordering than self.rows and self.cols

resolves #60