### PR TITLE
Both left and right eigenvectors computations.

### DIFF
--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -27,7 +27,7 @@ class Beyn(NEVP):
         The outer radius of the annulus for the contour integration.
     r_i : float
         The inner radius of the annulus for the contour integration.
-    c_hat : int
+    m_0 : int
         Guess for the number of eigenvalues that lie in the subspace.
     num_quad_points : int
         The number of quadrature points to use for the contour
@@ -39,16 +39,16 @@ class Beyn(NEVP):
         self,
         r_o: float,
         r_i: float,
-        c_hat: int,
+        m_0: int,
         num_quad_points: int,
     ):
         """Initializes the Beyn NEVP solver."""
         self.r_o = r_o
         self.r_i = r_i
-        self.c_hat = c_hat
+        self.m_0 = m_0
         self.num_quad_points = num_quad_points
 
-    def __call__(self, a_xx: tuple[NDArray, ...]) -> tuple[NDArray, NDArray]:
+    def _one_sided(self, a_xx: tuple[NDArray, ...]) -> tuple[NDArray, NDArray]:
         """Solves the plynomial eigenvalue problem.
 
         This method solves the non-linear eigenvalue problem defined by
@@ -78,8 +78,8 @@ class Beyn(NEVP):
         batchsize = a_xx[0].shape[0]
 
         # NOTE: Here we could also use a good initial guess.
-        Y = rng.random((batchsize, d, self.c_hat)) + 1j * rng.random(
-            (batchsize, d, self.c_hat)
+        Y = rng.random((batchsize, d, self.m_0)) + 1j * rng.random(
+            (batchsize, d, self.m_0)
         )
 
         # Determine quadrature points and weights.
@@ -103,10 +103,10 @@ class Beyn(NEVP):
         P_1 = xp.sum(w * z_o**2 * inv_Tz_o - w * z_i**2 * inv_Tz_i, axis=1) @ Y
 
         # Get the eigenvalues and eigenvectors.
-        ws = xp.zeros((batchsize, self.c_hat), dtype=in_type)
+        ws = xp.zeros((batchsize, self.m_0), dtype=in_type)
         vs = Y.copy()
 
-        # TODO: Batch even if the reduced size is smaller than c_hat.
+        # TODO: Batch even if the reduced size is smaller than m_0.
         for i in range(batchsize):
             # Perform an SVD on the linear subspace projector.
             u, s, vh = xp.linalg.svd(P_0[i], full_matrices=False)
@@ -126,3 +126,152 @@ class Beyn(NEVP):
             vs[i, :, : len(inds)] = u @ get_device(v)
 
         return ws, vs
+
+    def _two_sided(
+        self, a_xx: tuple[NDArray, ...]
+    ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+        """Solves the plynomial eigenvalue problem.
+
+        This method solves the non-linear eigenvalue problem defined by
+        the coefficient blocks `a_xx` from lowest to highest order.
+
+        Parameters
+        ----------
+        a_xx : tuple[NDArray, ...]
+            The coefficient blocks of the non-linear eigenvalue problem
+            from lowest to highest order.
+
+        Returns
+        -------
+        ws : NDArray
+            The right eigenvalues.
+        vs : NDArray
+            The right eigenvectors.
+        wl : NDArray
+            The left eigenvalues.
+        vl : NDArray
+            The left eigenvectors.
+
+        """
+        d = a_xx[0].shape[-1]
+        in_type = a_xx[0].dtype
+
+        # Allow for batched input.
+        if a_xx[0].ndim == 2:
+            a_xx = tuple(a_x[xp.newaxis, :, :] for a_x in a_xx)
+
+        batchsize = a_xx[0].shape[0]
+
+        # NOTE: Here we could also use a good initial guess.
+        Y = rng.random((batchsize, d, self.m_0)) + 1j * rng.random(
+            (batchsize, d, self.m_0)
+        )
+        Y_hat = rng.random((batchsize, d, self.m_0)) + 1j * rng.random(
+            (batchsize, d, self.m_0)
+        )
+
+        # Determine quadrature points and weights.
+        zeta = xp.arange(self.num_quad_points) + 1
+        phase = xp.exp(2j * xp.pi * (zeta + 0.5) / self.num_quad_points)
+        z_o = self.r_o * phase
+        z_i = self.r_i * phase
+        w = xp.ones(self.num_quad_points) / self.num_quad_points
+
+        # Reshape to broadcast over batch dimension.
+        z_o = z_o.reshape(1, -1, 1, 1)
+        z_i = z_i.reshape(1, -1, 1, 1)
+        w = w.reshape(1, -1, 1, 1)
+
+        a_xx = [a_x[:, xp.newaxis, :, :] for a_x in a_xx]
+        inv_Tz_o = operator_inverse(a_xx, z_o, in_type, in_type)
+        inv_Tz_i = operator_inverse(a_xx, z_i, in_type, in_type)
+
+        q0 = xp.sum(w * z_o * inv_Tz_o - w * z_i * inv_Tz_i, axis=1)
+        q1 = xp.sum(w * z_o**2 * inv_Tz_o - w * z_i**2 * inv_Tz_i, axis=1)
+
+        # Compute first and second moment.
+        P_0 = q0 @ Y
+        P_1 = q1 @ Y
+
+        P_0_hat = Y_hat.conj().swapaxes(-2, -1) @ q0
+        P_1_hat = Y_hat.conj().swapaxes(-2, -1) @ q1
+
+        # Get the eigenvalues and eigenvectors.
+        wrs = xp.zeros((batchsize, self.m_0), dtype=in_type)
+        vrs = xp.zeros((batchsize, d, self.m_0), dtype=in_type)
+        wls = xp.zeros((batchsize, self.m_0), dtype=in_type)
+        vls = xp.zeros((batchsize, d, self.m_0), dtype=in_type)
+
+        # TODO: Batch even if the reduced size is smaller than m_0.
+        for i in range(batchsize):
+            # Perform an SVD on the linear subspace projector.
+            u, s, vh = xp.linalg.svd(P_0[i], full_matrices=False)
+            u_hat, s_hat, vh_hat = xp.linalg.svd(P_0_hat[i], full_matrices=False)
+
+            # Remove the zero singular values (within numerical tolerance).
+            # and orthogonalize projector
+            eps_svd = s.max() * d * xp.finfo(in_type).eps
+            eps_svd_hat = s_hat.max() * d * xp.finfo(in_type).eps
+            inds = xp.where(s > eps_svd)[0]
+            inds_hat = xp.where(s_hat > eps_svd_hat)[0]
+
+            u, s, vh = u[:, inds], s[inds], vh[inds, :]
+            u_hat, s_hat, vh_hat = (
+                u_hat[:, inds_hat],
+                s_hat[inds_hat],
+                vh_hat[inds_hat, :],
+            )
+
+            # Probe second moment.
+            a = get_host(u.conj().T @ P_1[i] @ vh.conj().T / s)
+            # NOTE: xp.diag is unnecessary, should be removed
+            a_hat = get_host(
+                xp.diag(1 / s_hat) @ u_hat.conj().T @ P_1_hat[i] @ vh_hat.conj().T
+            )
+
+            w, v = np.linalg.eig(a)
+            w_hat, v_hat = np.linalg.eig(a_hat)
+
+            # Recover the full eigenvectors from the subspace.
+            wrs[i, : len(inds)] = get_device(w)
+            wls[i, : len(inds_hat)] = get_device(w_hat)
+
+            v, v_hat = get_device(v), get_device(v_hat)
+            vrs[i, :, : len(inds)] = u @ v
+            vls[i, :, : len(inds_hat)] = xp.linalg.solve(v_hat, vh_hat).conj().T
+
+        return wrs, vrs, wls, vls
+
+    def __call__(
+        self, a_xx: tuple[NDArray, ...], left: bool = False
+    ) -> tuple[NDArray, NDArray]:
+        """Solves the plynomial eigenvalue problem.
+
+        This method solves the non-linear eigenvalue problem defined by
+        the coefficient blocks `a_xx` from lowest to highest order.
+
+        Parameters
+        ----------
+        a_xx : tuple[NDArray, ...]
+            The coefficient blocks of the non-linear eigenvalue problem
+            from lowest to highest order.
+        left : bool, optional
+            Whether to solve additionally for the left eigenvectors.
+
+        Returns
+        -------
+        ws : NDArray
+            The right eigenvalues.
+        vs : NDArray
+            The right eigenvectors.
+        wl : NDArray, optional
+            The left eigenvalues.
+            Returned only if `left` is `True`.
+        vl : NDArray, optional
+            The left eigenvectors.
+            Returned only if `left` is `True`.
+
+        """
+        if left:
+            return self._two_sided(a_xx)
+        return self._one_sided(a_xx)

--- a/src/qttools/nevp/nevp.py
+++ b/src/qttools/nevp/nevp.py
@@ -9,7 +9,7 @@ class NEVP(ABC):
     """Abstract base class for the non-linear eigenvalue solvers."""
 
     @abstractmethod
-    def __call__(self, a_xx: tuple[NDArray, ...]) -> tuple[NDArray, NDArray]:
+    def __call__(self, a_xx: tuple[NDArray, ...], left: bool = False) -> tuple:
         r"""Solves the plynomial eigenvalue problem.
 
         This method solves the non-linear eigenvalue problem defined by
@@ -24,13 +24,21 @@ class NEVP(ABC):
         a_xx : tuple[NDArray, ...]
             The coefficient blocks of the non-linear eigenvalue problem
             from lowest to highest order.
+        left : bool, optional
+            Whether to solve additionally for the left eigenvectors.
 
         Returns
         -------
         ws : NDArray
-            The eigenvalues.
+            The right eigenvalues.
         vs : NDArray
-            The eigenvectors.
+            The right eigenvectors.
+        wl : NDArray, optional
+            The left eigenvalues.
+            Returned only if `left` is `True`.
+        vl : NDArray, optional
+            The left eigenvectors.
+            Returned only if `left` is `True`.
 
         """
         ...

--- a/tests/nevp/conftest.py
+++ b/tests/nevp/conftest.py
@@ -17,8 +17,9 @@ BLOCK_SIZE = [
 # a very large number to ensure that the non-spurious eigenvalues get
 # approximated very accurately.
 SUBSPACE_NEVP_SOLVERS = [
-    pytest.param(Beyn(r_o=1.2, r_i=0.9, c_hat=60, num_quad_points=200), id="Beyn")
+    pytest.param(Beyn(r_o=1.2, r_i=0.9, m_0=60, num_quad_points=200), id="Beyn")
 ]
+LEFT = [pytest.param(True, id="both"), pytest.param(False, id="right")]
 
 
 # TODO: It's a good idea to generalize the tests with input data
@@ -38,4 +39,10 @@ def a_xx(request: pytest.FixtureRequest) -> NDArray:
 @pytest.fixture(params=SUBSPACE_NEVP_SOLVERS)
 def subspace_nevp(request: pytest.FixtureRequest) -> NEVP:
     """Returns a NEVP solver."""
+    return request.param
+
+
+@pytest.fixture(params=LEFT)
+def left(request: pytest.FixtureRequest) -> bool:
+    """Whether to solve for the left eigenvectors."""
     return request.param

--- a/tests/nevp/test_nevp.py
+++ b/tests/nevp/test_nevp.py
@@ -7,31 +7,54 @@ from qttools import NDArray, xp
 from qttools.nevp import Beyn, Full
 
 
-def test_full(a_xx: tuple[NDArray, ...]):
+@pytest.mark.usefixtures("left")
+def test_full(a_xx: tuple[NDArray, ...], left: bool):
     """Tests that the Full NEVP solver returns the correct result."""
     full_nevp = Full()
-    ws, vs = full_nevp(a_xx)
+    if left:
+        wrs, vrs, wls, vls = full_nevp(a_xx, left=left)
+    else:
+        wrs, vrs = full_nevp(a_xx, left=left)
+
     a_ji, a_ii, a_ij = a_xx
 
-    for i in range(ws.shape[1]):
-        w = ws[0, i]
-        v = vs[0, :, i] / xp.linalg.norm(vs[0, :, i])
+    for i in range(wrs.shape[1]):
+        w = wrs[0, i]
+        v = vrs[0, :, i] / xp.linalg.norm(vrs[0, :, i])
 
         assert xp.allclose((a_ji / w + a_ii + a_ij * w) @ v, 0)
 
+    if left:
+        for i in range(wrs.shape[1]):
+            w = wls[0, i]
+            v = vls[0, :, i] / xp.linalg.norm(vls[0, :, i])
 
-@pytest.mark.usefixtures("subspace_nevp")
-def test_subspace(a_xx: tuple[NDArray, ...], subspace_nevp: Beyn):
+            assert xp.allclose(v.conj().T @ (a_ji / w + a_ii + a_ij * w), 0)
+
+
+@pytest.mark.usefixtures("subspace_nevp", "left")
+def test_subspace(a_xx: tuple[NDArray, ...], subspace_nevp: Beyn, left: bool):
     """Tests that the subspace NEVP solver returns the correct result."""
-    ws, vs = subspace_nevp(a_xx)
+    if left:
+        wrs, vrs, wls, vls = subspace_nevp(a_xx, left=left)
+    else:
+        wrs, vrs = subspace_nevp(a_xx, left=left)
 
     a_ji, a_ii, a_ij = a_xx
     residuals = []
-    for k in range(ws.shape[1]):
-        w = ws[0, k]
-        v = vs[0, :, k] / xp.linalg.norm(vs[0, :, k])
+    for k in range(wrs.shape[1]):
+        w = wrs[0, k]
+        v = vrs[0, :, k] / xp.linalg.norm(vrs[0, :, k])
         with np.errstate(divide="ignore", invalid="ignore"):
             residuals.append(xp.linalg.norm((a_ji / w + a_ii + a_ij * w) @ v))
+    if left:
+        for k in range(wrs.shape[1]):
+            w = wls[0, k]
+            v = vls[0, :, k] / xp.linalg.norm(vls[0, :, k])
+            with np.errstate(divide="ignore", invalid="ignore"):
+                residuals.append(
+                    xp.linalg.norm(v.conj().T @ (a_ji / w + a_ii + a_ij * w))
+                )
 
     residuals = xp.nan_to_num(xp.array(residuals))
 

--- a/tests/obc/conftest.py
+++ b/tests/obc/conftest.py
@@ -13,7 +13,7 @@ from qttools.nevp import NEVP, Beyn, Full
 # quadrature points is set such that non-spurious eigenvalues get
 # approximated accurately enough.
 NEVP_SOLVERS = [
-    pytest.param(Beyn(r_o=200, r_i=0.9, c_hat=23, num_quad_points=13), id="Beyn"),
+    pytest.param(Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13), id="Beyn"),
     pytest.param(Full(), id="Full"),
 ]
 
@@ -30,6 +30,10 @@ BLOCK_SECTIONS = [
 ]
 
 CONTACTS = ["left", "right"]
+
+TWO_SIDED = [True, False]
+
+TREAT_PAIRWISE = [True, False]
 
 
 @pytest.fixture(params=X_II_FORMULAS)
@@ -73,4 +77,16 @@ def a_xx(request: pytest.FixtureRequest) -> tuple[NDArray, NDArray, NDArray]:
 @pytest.fixture(params=CONTACTS, autouse=True)
 def contact(request: pytest.FixtureRequest) -> str:
     """Returns a contact."""
+    return request.param
+
+
+@pytest.fixture(params=TWO_SIDED)
+def two_sided(request: pytest.FixtureRequest) -> bool:
+    """Whether only right eigenvectors or both are used."""
+    return request.param
+
+
+@pytest.fixture(params=TREAT_PAIRWISE)
+def treat_pairwise(request: pytest.FixtureRequest) -> bool:
+    """Whether the eigenvalues are pairwise filtered."""
     return request.param

--- a/tests/obc/test_spectral.py
+++ b/tests/obc/test_spectral.py
@@ -42,6 +42,8 @@ def _make_periodic(
     "nevp",
     "x_ii_formula",
     "block_sections",
+    "two_sided",
+    "treat_pairwise",
 )
 def test_correctness(
     a_xx: tuple[NDArray, ...],
@@ -49,10 +51,16 @@ def test_correctness(
     block_sections: int,
     x_ii_formula: str,
     contact: str,
+    two_sided: bool,
+    treat_pairwise: bool,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
-        nevp=nevp, block_sections=block_sections, x_ii_formula=x_ii_formula
+        nevp=nevp,
+        block_sections=block_sections,
+        x_ii_formula=x_ii_formula,
+        two_sided=two_sided,
+        treat_pairwise=treat_pairwise,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
     x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
@@ -63,6 +71,8 @@ def test_correctness(
     "nevp",
     "x_ii_formula",
     "block_sections",
+    "two_sided",
+    "treat_pairwise",
 )
 def test_correctness_batch(
     a_xx: tuple[NDArray, ...],
@@ -70,10 +80,16 @@ def test_correctness_batch(
     block_sections: int,
     x_ii_formula: str,
     contact: str,
+    two_sided: bool,
+    treat_pairwise: bool,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
-        nevp=nevp, block_sections=block_sections, x_ii_formula=x_ii_formula
+        nevp=nevp,
+        block_sections=block_sections,
+        x_ii_formula=x_ii_formula,
+        two_sided=two_sided,
+        treat_pairwise=treat_pairwise,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
     a_ji = xp.stack([a_ji for __ in range(10)])


### PR DESCRIPTION
# Enables solving for both left and right eigenpairs
- Extends the nevp interface, and the full and beyn polynomial eigenvalue solvers
- Adapats the spectral OBC calculation to allow for:
1. Matching of left and right eigenpairs
2. Peudo inverse combining both left and right eigenvectors 
3. dE_dk calculation with both left and right eigenvectors 
- Includes the options in the nevp and OBC tests