### PR TITLE
Implement additionally filtering out states with high residual

### DIFF
--- a/src/qttools/obc/spectral.py
+++ b/src/qttools/obc/spectral.py
@@ -58,6 +58,16 @@ class Spectral(OBCSolver):
         The minimum ratio between the real and imaginary part of the
         group velocity of a mode. This ratio is used to determine how
         clearly a mode propagates.
+    residual_tolerance : float, optional
+        The tolerance for the residual of the NEVP.
+    residual_normalization_formula : str, optional
+        The formula to use for the normalization of the residual. The
+        default is the "operator_norm" formula. The other options are
+        "abs_eigenvalue" and "no_normalization".The "operator_norm"
+        formula corresponds to normalization by the frobenius norm of
+        the operator, the "abs_eigenvalue" formula corresponds to
+        normalization by the absolute of the eigenvalues, and
+        "no_normalization" results in no normalization.
 
         [^1]: S. Brück, et al., Efficient algorithms for large-scale
         quantum transport calculations, The Journal of Chemical Physics,
@@ -77,6 +87,8 @@ class Spectral(OBCSolver):
         treat_pairwise: bool = True,
         pairing_threshold: float = 0.25,
         min_propagation: float = 0.01,
+        residual_tolerance: float = 1e-3,
+        residual_normalization_formula: str = "operator_norm",
         warning_threshold: float = 1e-1,
     ) -> None:
         """Initializes the spectral OBC solver."""
@@ -95,6 +107,8 @@ class Spectral(OBCSolver):
         self.treat_pairwise = treat_pairwise
         self.pairing_threshold = pairing_threshold
         self.min_propagation = min_propagation
+        self.residual_tolerance = residual_tolerance
+        self.residual_normalization_formula = residual_normalization_formula
         self.warning_threshold = warning_threshold
 
     def _extract_subblocks(
@@ -278,6 +292,39 @@ class Spectral(OBCSolver):
         if self.two_sided and vls is None:
             raise ValueError("Two-sided calculation requires left eigenvectors.")
 
+        # Calculate the residual
+        with warnings.catch_warnings(action="ignore", category=RuntimeWarning):
+            # NOTE: This consumes a lot of memory since
+            # the operators are explicitly calculated.
+            operators = sum(
+                a_x[:, xp.newaxis, :, :]
+                * ws[..., xp.newaxis, xp.newaxis] ** (i - len(a_xx) // 2)
+                for i, a_x in enumerate(a_xx)
+            )
+            products = operators @ vrs.swapaxes(-1, -2)[..., xp.newaxis]
+
+            residuals = xp.linalg.norm(products, axis=(-1, -2))
+
+            # eigenvectors are not necessarily normalized
+            eigenvector_norm = xp.linalg.norm(vrs, axis=-2)
+            residuals /= eigenvector_norm
+
+            if self.residual_normalization_formula == "operator_norm":
+                operator_norm = xp.linalg.norm(operators, axis=(-1, -2))
+                residuals /= operator_norm
+            elif self.residual_normalization_formula == "abs_eigenvalue":
+                residuals /= xp.abs(ws)
+            elif self.residual_normalization_formula == "no_normalization":
+                pass
+            else:
+                raise ValueError(
+                    f"Unknown formula: {self.residual_normalization_formula}"
+                    "Choose 'operator_norm', 'abs_eigenvalue', or 'no_normalization'."
+                )
+
+            if xp.any(residuals > self.residual_tolerance):
+                print("Warning: Residuals are larger than the tolerance.")
+
         # Calculate the group velocity to select propagation direction.
         # The formula can be derived by taking the derivative of the
         # polynomial eigenvalue equation with respect to k.
@@ -320,7 +367,9 @@ class Spectral(OBCSolver):
         # ingore modes that decay incredibly fast
         mask_decaying &= ks.imag > -self.max_decay
 
-        return mask_propagating | mask_decaying
+        return (mask_propagating | mask_decaying) & (
+            residuals < self.residual_tolerance
+        )
 
     def _upscale_eigenmodes(
         self,

--- a/tests/obc/conftest.py
+++ b/tests/obc/conftest.py
@@ -40,6 +40,12 @@ TWO_SIDED = [True, False]
 
 TREAT_PAIRWISE = [True, False]
 
+RESIDUAL_NORMALIZATION_FORMULAS = [
+    "operator_norm",
+    "abs_eigenvalue",
+    "no_normalization",
+]
+
 
 @pytest.fixture(params=X_II_FORMULAS)
 def x_ii_formula(request: pytest.FixtureRequest) -> str:
@@ -106,4 +112,10 @@ def two_sided(request: pytest.FixtureRequest) -> bool:
 @pytest.fixture(params=TREAT_PAIRWISE)
 def treat_pairwise(request: pytest.FixtureRequest) -> bool:
     """Whether the eigenvalues are pairwise filtered."""
+    return request.param
+
+
+@pytest.fixture(params=RESIDUAL_NORMALIZATION_FORMULAS)
+def residual_normalization_formula(request: pytest.FixtureRequest) -> str:
+    """Returns a residual normalization formula."""
     return request.param

--- a/tests/obc/conftest.py
+++ b/tests/obc/conftest.py
@@ -40,11 +40,7 @@ TWO_SIDED = [True, False]
 
 TREAT_PAIRWISE = [True, False]
 
-RESIDUAL_NORMALIZATION_FORMULAS = [
-    "operator_norm",
-    "abs_eigenvalue",
-    "no_normalization",
-]
+RESIDUAL_NORMALIZATION_FORMULAS = ["operator", "eigenvalue", None]
 
 
 @pytest.fixture(params=X_II_FORMULAS)
@@ -116,6 +112,6 @@ def treat_pairwise(request: pytest.FixtureRequest) -> bool:
 
 
 @pytest.fixture(params=RESIDUAL_NORMALIZATION_FORMULAS)
-def residual_normalization_formula(request: pytest.FixtureRequest) -> str:
+def residual_normalization(request: pytest.FixtureRequest) -> str | None:
     """Returns a residual normalization formula."""
     return request.param

--- a/tests/obc/test_spectral.py
+++ b/tests/obc/test_spectral.py
@@ -44,6 +44,7 @@ def _make_periodic(
     "block_sections",
     "two_sided",
     "treat_pairwise",
+    "residual_normalization_formula",
 )
 def test_correctness(
     a_xx: tuple[NDArray, ...],
@@ -53,6 +54,7 @@ def test_correctness(
     contact: str,
     two_sided: bool,
     treat_pairwise: bool,
+    residual_normalization_formula: str,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
@@ -61,6 +63,7 @@ def test_correctness(
         x_ii_formula=x_ii_formula,
         two_sided=two_sided,
         treat_pairwise=treat_pairwise,
+        residual_normalization_formula=residual_normalization_formula,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
     x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
@@ -73,6 +76,7 @@ def test_correctness(
     "block_sections",
     "two_sided",
     "treat_pairwise",
+    "residual_normalization_formula",
 )
 def test_correctness_batch(
     a_xx: tuple[NDArray, ...],
@@ -82,6 +86,7 @@ def test_correctness_batch(
     contact: str,
     two_sided: bool,
     treat_pairwise: bool,
+    residual_normalization_formula: str,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
@@ -90,6 +95,7 @@ def test_correctness_batch(
         x_ii_formula=x_ii_formula,
         two_sided=two_sided,
         treat_pairwise=treat_pairwise,
+        residual_normalization_formula=residual_normalization_formula,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
     a_ji = xp.stack([a_ji for __ in range(10)])

--- a/tests/obc/test_spectral.py
+++ b/tests/obc/test_spectral.py
@@ -44,7 +44,7 @@ def _make_periodic(
     "block_sections",
     "two_sided",
     "treat_pairwise",
-    "residual_normalization_formula",
+    "residual_normalization",
 )
 def test_correctness(
     a_xx: tuple[NDArray, ...],
@@ -54,7 +54,7 @@ def test_correctness(
     contact: str,
     two_sided: bool,
     treat_pairwise: bool,
-    residual_normalization_formula: str,
+    residual_normalization: str | None,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
@@ -63,7 +63,7 @@ def test_correctness(
         x_ii_formula=x_ii_formula,
         two_sided=two_sided,
         treat_pairwise=treat_pairwise,
-        residual_normalization_formula=residual_normalization_formula,
+        residual_normalization=residual_normalization,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
     x_ii = spectral(a_ii=a_ii, a_ij=a_ij, a_ji=a_ji, contact=contact)
@@ -76,7 +76,7 @@ def test_correctness(
     "block_sections",
     "two_sided",
     "treat_pairwise",
-    "residual_normalization_formula",
+    "residual_normalization",
 )
 def test_correctness_batch(
     a_xx: tuple[NDArray, ...],
@@ -86,7 +86,7 @@ def test_correctness_batch(
     contact: str,
     two_sided: bool,
     treat_pairwise: bool,
-    residual_normalization_formula: str,
+    residual_normalization: str,
 ):
     """Tests that the OBC return the correct result."""
     spectral = Spectral(
@@ -95,7 +95,7 @@ def test_correctness_batch(
         x_ii_formula=x_ii_formula,
         two_sided=two_sided,
         treat_pairwise=treat_pairwise,
-        residual_normalization_formula=residual_normalization_formula,
+        residual_normalization=residual_normalization,
     )
     a_ji, a_ii, a_ij = _make_periodic(a_xx, block_sections)
     a_ji = xp.stack([a_ji for __ in range(10)])


### PR DESCRIPTION
The filtering is needed if an algorithm like Beyn produces
eigenpairs which are badly approximated and thus
should not be considered for the self-energy.
Different normalizations are possible like the absolute value of the eigenvalue or the norm of the operator.

This pull request fixes #79.