### PR TITLE
Add OBCBlocks class and integrate into GFSolver implementations.

### DIFF
--- a/src/qttools/greens_function_solver/inv.py
+++ b/src/qttools/greens_function_solver/inv.py
@@ -2,7 +2,7 @@
 
 from qttools import xp
 from qttools.datastructures.dsbsparse import DSBSparse
-from qttools.greens_function_solver.solver import GFSolver
+from qttools.greens_function_solver.solver import GFSolver, OBCBlocks
 from qttools.utils.solvers_utils import get_batches
 
 
@@ -19,16 +19,19 @@ class Inv(GFSolver):
     ----------
     max_batch_size : int, optional
         Maximum batch size to use when inverting the matrix, by default
-        1.
+        100.
 
     """
 
-    def __init__(self, max_batch_size: int = 1) -> None:
+    def __init__(self, max_batch_size: int = 100) -> None:
         """Initializes the selected inversion solver."""
         self.max_batch_size = max_batch_size
 
     def selected_inv(
-        self, a: DSBSparse, out: DSBSparse | None = None
+        self,
+        a: DSBSparse,
+        obc_blocks: OBCBlocks | None = None,
+        out: DSBSparse | None = None,
     ) -> None | DSBSparse:
         """Performs selected inversion of a block-tridiagonal matrix.
 
@@ -40,6 +43,9 @@ class Inv(GFSolver):
         ----------
         a : DSBSparse
             Matrix to invert.
+        obc_blocks : OBCBlocks, optional
+            OBC blocks for lesser, greater and retarded Green's
+            functions. By default None.
         out : DSBSparse, optional
             Preallocated output matrix, by default None.
 
@@ -53,8 +59,12 @@ class Inv(GFSolver):
         # Get list of batches to perform
         batches_sizes, batches_slices = get_batches(a.shape[0], self.max_batch_size)
 
+        if obc_blocks is None:
+            obc_blocks = OBCBlocks(num_blocks=a.num_blocks)
+
         # Allocate batching buffer
         inv_a = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
+        obc = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
 
         # Prepare output
         return_out = False
@@ -68,10 +78,22 @@ class Inv(GFSolver):
         # Perform the inversion in batches
         for i in range(len(batches_sizes)):
             stack_slice = slice(batches_slices[i], batches_slices[i + 1], 1)
+            obc[:] = 0  # Reset the OBC blocks.
 
-            inv_a[: batches_sizes[i]] = xp.linalg.inv(a.to_dense())[stack_slice, ...]
+            # Assemble the OBC blocks.
+            for j, block in enumerate(obc_blocks.retarded):
+                if block is None:
+                    continue
+                block_slice = slice(a.block_offsets[j], a.block_offsets[j + 1], 1)
+                obc[: batches_sizes[i], block_slice, block_slice] = block.retarded[
+                    stack_slice
+                ]
 
-            out.data[stack_slice,] = inv_a[: batches_sizes[i], ..., rows, cols]
+            inv_a[: batches_sizes[i]] = xp.linalg.inv(
+                a.to_dense()[stack_slice] - obc[: batches_sizes[i]]
+            )
+
+            out.data[stack_slice] = inv_a[: batches_sizes[i], ..., rows, cols]
 
         if return_out:
             return out
@@ -81,8 +103,10 @@ class Inv(GFSolver):
         a: DSBSparse,
         sigma_lesser: DSBSparse,
         sigma_greater: DSBSparse,
+        obc_blocks: OBCBlocks | None = None,
         out: tuple[DSBSparse, ...] | None = None,
         return_retarded: bool = False,
+        return_current: bool = False,
     ) -> None | tuple:
         r"""Produces elements of the solution to the congruence equation.
 
@@ -103,12 +127,18 @@ class Inv(GFSolver):
         sigma_greater : DSBSparse
             Greater matrix. This matrix is expected to be
             skew-hermitian, i.e. \(\Sigma_{ij} = -\Sigma_{ji}^*\).
+        obc_blocks : OBCBlocks, optional
+            OBC blocks for lesser, greater and retarded Green's
+            functions. By default None.
         out : tuple[DSBSparse, ...] | None, optional
             Preallocated output matrices, by default None
         return_retarded : bool, optional
             Wether the retarded Green's function should be returned
             along with lesser and greater, by default False
-
+        return_current : bool, optional
+            Whether to compute and return the current for each layer via
+            the Meir-Wingreen formula. By default False. This option is
+            not implemented.
 
         Returns
         -------
@@ -119,13 +149,25 @@ class Inv(GFSolver):
             last element.
 
         """
+        if return_current:
+            raise NotImplementedError(
+                "The computation of the current is not implemented."
+            )
+
         # Get list of batches to perform
         batches_sizes, batches_slices = get_batches(a.shape[0], self.max_batch_size)
+
+        if obc_blocks is None:
+            obc_blocks = OBCBlocks(num_blocks=a.num_blocks)
 
         # Allocate batching buffer
         x_r = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
         x_l = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
         x_g = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
+
+        obc_r = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
+        obc_l = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
+        obc_g = xp.zeros((max(batches_sizes), *a.shape[1:]), dtype=a.dtype)
 
         # Prepare output
         if out is None:
@@ -152,15 +194,29 @@ class Inv(GFSolver):
         for i in range(len(batches_sizes)):
             stack_slice = slice(batches_slices[i], batches_slices[i + 1], 1)
 
-            x_r[: batches_sizes[i]] = xp.linalg.inv(a.to_dense())[stack_slice, ...]
+            # Assemble the OBC blocks.
+            for j, (block_r, block_l, block_g) in enumerate(
+                zip(obc_blocks.retarded, obc_blocks.lesser, obc_blocks.greater)
+            ):
+                b_ = slice(a.block_offsets[j], a.block_offsets[j + 1], 1)
+                if block_r is not None:
+                    obc_r[: batches_sizes[i], b_, b_] = block_r[stack_slice]
+                if block_l is not None:
+                    obc_l[: batches_sizes[i], b_, b_] = block_l[stack_slice]
+                if block_g is not None:
+                    obc_g[: batches_sizes[i], b_, b_] = block_g[stack_slice]
+
+            x_r[: batches_sizes[i]] = xp.linalg.inv(
+                a.to_dense()[stack_slice] - obc_r[: batches_sizes[i]]
+            )
             x_l[: batches_sizes[i]] = (
                 x_r[: batches_sizes[i]]
-                @ sigma_lesser.to_dense()[: batches_sizes[i]]
+                @ (sigma_lesser.to_dense()[stack_slice] + obc_l[: batches_sizes[i]])
                 @ x_r[: batches_sizes[i]].conj().swapaxes(-2, -1)
             )
             x_g[: batches_sizes[i]] = (
                 x_r[: batches_sizes[i]]
-                @ sigma_greater.to_dense()[: batches_sizes[i]]
+                @ (sigma_greater.to_dense()[stack_slice] + obc_g[: batches_sizes[i]])
                 @ x_r[: batches_sizes[i]].conj().swapaxes(-2, -1)
             )
 

--- a/src/qttools/greens_function_solver/solver.py
+++ b/src/qttools/greens_function_solver/solver.py
@@ -2,20 +2,51 @@
 
 from abc import ABC, abstractmethod
 
+from qttools import NDArray
 from qttools.datastructures import DSBSparse
+
+
+# NOTE: Maybe it's overkill to have a class for this, but makes the
+# grouping a bit easier. Also thinking forward to the possibility of
+# adding more contacts in the future.
+class OBCBlocks:
+    """Class to hold the OBC blocks used in the GF solvers.
+
+    This class holds the OBC blocks for lesser, greater and retarded
+    Green's functions. These are lists of NDArray objects.
+
+    Parameters
+    ----------
+    num_blocks : int
+        Number of blocks in the structure.
+
+    """
+
+    def __init__(self, num_blocks: int):
+        self.retarded: list[NDArray | None] = [None] * num_blocks
+        self.lesser: list[NDArray | None] = [None] * num_blocks
+        self.greater: list[NDArray | None] = [None] * num_blocks
 
 
 class GFSolver(ABC):
     """Abstract base class for the Green's function solvers."""
 
     @abstractmethod
-    def selected_inv(self, a: DSBSparse, out: DSBSparse = None) -> None | DSBSparse:
+    def selected_inv(
+        self,
+        a: DSBSparse,
+        obc_blocks: OBCBlocks | None = None,
+        out: DSBSparse = None,
+    ) -> None | DSBSparse:
         """Performs selected inversion of a block-tridiagonal matrix.
 
         Parameters
         ----------
         a : DSBSparse
             Matrix to invert.
+        obc_blocks : OBCBlocks, optional
+            OBC blocks for lesser, greater and retarded Green's
+            functions. By default None.
         out : DSBSparse, optional
             Preallocated output matrix, by default None.
 
@@ -34,8 +65,10 @@ class GFSolver(ABC):
         a: DSBSparse,
         sigma_lesser: DSBSparse,
         sigma_greater: DSBSparse,
+        obc_blocks: OBCBlocks | None = None,
         out: tuple | None = None,
         return_retarded: bool = False,
+        return_current: bool = False,
     ) -> None | tuple:
         r"""Produces elements of the solution to the congruence equation.
 
@@ -56,11 +89,17 @@ class GFSolver(ABC):
         sigma_greater : DSBSparse
             Greater matrix. This matrix is expected to be
             skew-hermitian, i.e. \(\Sigma_{ij} = -\Sigma_{ji}^*\).
+        obc_blocks : dict[int, OBCBlocks], optional
+            OBC blocks for lesser, greater and retarded Green's
+            functions, by default None.
         out : tuple[DSBSparse, ...] | None, optional
             Preallocated output matrices, by default None
         return_retarded : bool, optional
             Wether the retarded Green's function should be returned
             along with lesser and greater, by default False
+        return_current : bool, optional
+            Whether to compute and return the current for each layer via
+            the Meir-Wingreen formula. By default False.
 
         Returns
         -------


### PR DESCRIPTION
Now the obc blocks are passed directly into the Green's function solvers. With this we don't explicitely have to densify those blocks in the DSBSparse inputs. This is also implemented in the Inv solver.

In the RGF i added the option for also computing this Meir-Wingreen current throughout the device. I do this differently than in the old code, now i only compute everything during the second pass, no additional memory required but the quantities are kind of computed in both passes.

I also changed a couple things where we did not exploit the skew-hermitian symmetry correctly before. Fewer block-densifications now.