### PR TITLE
Fix OBC Memoizer load balancing.

### DIFF
--- a/src/qttools/lyapunov/doubling.py
+++ b/src/qttools/lyapunov/doubling.py
@@ -19,7 +19,7 @@ class Doubling(LyapunovSolver):
     """
 
     def __init__(
-        self, max_iterations: int = 1000, convergence_tol: float = 1e-7
+        self, max_iterations: int = 100, convergence_tol: float = 1e-6
     ) -> None:
         """Initializes the solver."""
         self.max_iterations = max_iterations

--- a/src/qttools/obc/sancho_rubio.py
+++ b/src/qttools/obc/sancho_rubio.py
@@ -24,7 +24,7 @@ class SanchoRubio(OBCSolver):
 
     """
 
-    def __init__(self, max_iterations: int = 1000, convergence_tol: float = 1e-7):
+    def __init__(self, max_iterations: int = 100, convergence_tol: float = 1e-6):
         """Initializes the Sancho-Rubio OBC."""
         self.max_iterations = max_iterations
         self.convergence_tol = convergence_tol

--- a/src/qttools/obc/spectral.py
+++ b/src/qttools/obc/spectral.py
@@ -130,7 +130,6 @@ class Spectral(OBCSolver):
         view = _block_view(view, -2, self.block_sections)
 
         # Make sure that the reduction leads to periodic sublayers.
-        # NOTE: I'm not 100% sure that this is really necessary.
         relative_errors = xp.zeros(self.block_sections - 1)
         first_block_norm = xp.linalg.norm(view[0, :])
         for i in range(1, self.block_sections):


### PR DESCRIPTION
If any rank's memoizer fails to reach the targeted relative error, all ranks should recompute the OBC from scratch.

I also changed the test for block-sectioning periodicity since it was a bit too stringent for use in practice before.

The last changes mainly concern the default parameters. We consistently target a relative error of 1e-6 now. Also suppressed some warnings we don't care about...