### PR TITLE
Pythonic wrapper for cublas gemmEx and gemmBatchedEx

### DIFF
--- a/src/qttools/kernels/__init__.py
+++ b/src/qttools/kernels/__init__.py
@@ -15,5 +15,12 @@ elif xp.__name__ == "cupy":
 else:
     raise ValueError(f"Unrecognized ARRAY_MODULE '{xp.__name__}'")
 
+from qttools.kernels.gemmEx import gemm
 
-__all__ = ["dsbsparse_kernels", "dsbcoo_kernels", "dsbcsr_kernels", "obc_kernels"]
+__all__ = [
+    "dsbsparse_kernels",
+    "dsbcoo_kernels",
+    "dsbcsr_kernels",
+    "obc_kernels",
+    "gemm",
+]

--- a/src/qttools/kernels/gemmEx.py
+++ b/src/qttools/kernels/gemmEx.py
@@ -1,0 +1,301 @@
+from qttools import NDArray, xp
+
+if xp.__name__ == "cupy":
+    import cupy as cp
+    import numpy as np
+    from cupy._core import _dtype
+    from cupy.cuda import cublas, device
+
+
+def gemm(
+    a: NDArray,
+    b: NDArray,
+    c: None | NDArray = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    compute_type: None | str = None,
+) -> NDArray | None:
+    """Computes the General matrix-matrix product of three arrays: alpha * a @ b + beta * c.
+
+    Parameters
+    ----------
+    a : NDArray
+        The first input array.
+    b : NDArray
+        The second input array.
+    c : None or NDArray, optional
+        The third input array. If None, the result is returned in a new array.
+    alpha : float, optional
+        The scalar alpha, default is 1.0.
+    beta : float, optional
+        The scalar beta, default is 0.0.
+    compute_type : None or str, optional
+        The compute type to use. If None, the default compute type is used
+        which is the same as the dtype of the input arrays.
+        For float32 and complex64, the compute types are:
+        - "32F": 32-bit floating point
+        - "16F": 16-bit floating point
+        - "16BF": brain float
+        - "32TF": tensor float
+        For float64 and complex128, the compute types are:
+        - "64F": 64-bit floating point
+
+    Returns
+    -------
+    c : None or NDArray if c is None
+        The result of the matrix-matrix product.
+    """
+
+    if c is None and beta != 0.0:
+        # else gemmEx will make a wrong result
+        raise ValueError("c must be provided if beta is not zero")
+
+    if xp.__name__ == "numpy":
+        return _gemm_host(a, b, c, alpha, beta, compute_type)
+    elif xp.__name__ == "cupy":
+        xp.linalg._util._assert_cupy_array(a)
+        xp.linalg._util._assert_stacked_2d(a)
+
+        xp.linalg._util._assert_cupy_array(b)
+        xp.linalg._util._assert_stacked_2d(b)
+
+        if a.ndim <= 2:
+            return _gemm_device(a, b, c, alpha, beta, compute_type)
+        else:
+            return _batched_gemm_device(a, b, c, alpha, beta, compute_type)
+    else:
+        raise ValueError("Invalid backend")
+
+
+def _gemm_host(
+    a: NDArray,
+    b: NDArray,
+    c: None | NDArray = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    compute_type: None | str = None,
+):
+    dtype = xp.common_type(a, b)
+
+    if not (
+        (
+            (compute_type == "32F" or compute_type is None)
+            and (dtype == xp.float32 or dtype == xp.complex64)
+        )
+        or (
+            (compute_type == "64F" or compute_type is None)
+            and (dtype == xp.float64 or dtype == xp.complex128)
+        )
+    ):
+        raise ValueError("Invalid dtype and compute_type combination")
+
+    if c is None:
+        return alpha * xp.matmul(a, b)
+
+    c[:] = alpha * xp.matmul(a, b) + beta * c
+
+
+def _get_compute_type(dtype: xp.dtype, compute_type: str):
+    if compute_type == "16F" and (dtype == xp.float32 or dtype == xp.complex64):
+        return cublas.CUBLAS_COMPUTE_32F_FAST_16F
+    elif compute_type == "16BF" and (dtype == xp.float32 or dtype == xp.complex64):
+        return cublas.CUBLAS_COMPUTE_32F_FAST_16BF
+    elif (compute_type == "32F" or compute_type is None) and (
+        dtype == xp.float32 or dtype == xp.complex64
+    ):
+        return cublas.CUBLAS_COMPUTE_32F
+    elif compute_type == "32TF" and (dtype == xp.float32 or dtype == xp.complex64):
+        return cublas.CUBLAS_COMPUTE_32F_FAST_TF32
+    elif (compute_type == "64F" or compute_type is None) and (
+        dtype == xp.float64 or dtype == xp.complex128
+    ):
+        return cublas.CUBLAS_COMPUTE_64F
+    else:
+        raise ValueError("Invalid dtype and compute_type combination")
+
+
+def _gemm_device(
+    a: NDArray,
+    b: NDArray,
+    c: None | NDArray = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    compute_type: str = "default",
+):
+    # .ndim must be >= 3
+    if c is None:
+        dtype = xp.common_type(
+            a,
+            b,
+        )
+    else:
+        dtype = xp.common_type(
+            a,
+            b,
+            c,
+        )
+
+    if b.dtype != dtype:
+        raise ValueError("b's dtype must be the same as a dtype")
+
+    m = a.shape[-2]
+    n = b.shape[-1]
+    k = a.shape[-1]
+
+    if b.shape[-2] != k:
+        raise ValueError("b's shape[-2] must be equal to a's shape[-1]")
+
+    cublas_type = _dtype.to_cuda_dtype(xp.dtype(dtype))
+    cublas_compute_type = _get_compute_type(dtype, compute_type)
+
+    alpha = np.array(alpha, dtype=dtype)
+    beta = np.array(beta, dtype=dtype)
+
+    # potential copy is needed to ensure correct memory layout
+    # TODO: no memory copy, but correct strides
+    a = cp.ascontiguousarray(a, dtype=dtype)
+    b = cp.ascontiguousarray(b, dtype=dtype)
+
+    # allocate c if not provided
+    return_c = False
+    if c is None:
+        return_c = True
+        c = xp.empty((m, n), dtype=dtype)
+
+    if m == 0 or n == 0 or k == 0:
+        return c
+
+    # potential copy is needed to ensure correct memory layout
+    # and to avoid memory corruption
+    is_contiguous = c.flags["C_CONTIGUOUS"] or c.flags["F_CONTIGUOUS"]
+    is_fortran_order = c.flags["F_CONTIGUOUS"]
+    if not return_c and (is_fortran_order or not is_contiguous):
+        original_c = c
+        c = cp.ascontiguousarray(c, dtype=dtype)
+
+    handle = device.get_cublas_handle()
+
+    cublas.gemmEx(
+        handle,
+        cublas.CUBLAS_OP_N,
+        cublas.CUBLAS_OP_N,
+        n,
+        m,
+        k,
+        alpha.ctypes.data,
+        b.data.ptr,
+        cublas_type,
+        n,
+        a.data.ptr,
+        cublas_type,
+        k,
+        beta.ctypes.data,
+        c.data.ptr,
+        cublas_type,
+        n,
+        cublas_compute_type,
+        cublas.CUBLAS_GEMM_DEFAULT,
+    )
+
+    if return_c:
+        return c
+    elif is_fortran_order or not is_contiguous:
+        original_c[:] = c
+
+
+def _batched_gemm_device(
+    a: NDArray,
+    b: NDArray,
+    c: None | NDArray = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    compute_type: str = "default",
+):
+    # .ndim must be >= 3
+    if c is None:
+        dtype = xp.common_type(
+            a,
+            b,
+        )
+    else:
+        dtype = xp.common_type(
+            a,
+            b,
+            c,
+        )
+
+    if b.dtype != dtype:
+        raise ValueError("b's dtype must be the same as a dtype")
+
+    m = a.shape[-2]
+    n = b.shape[-1]
+    k = a.shape[-1]
+    batchshape = a.shape[:-2]
+
+    if b.shape[-2] != k:
+        raise ValueError("b's shape[-2] must be equal to a's shape[-1]")
+    if batchshape != b.shape[:-2]:
+        raise ValueError("a and b must have the same batchshape")
+
+    cublas_type = _dtype.to_cuda_dtype(xp.dtype(dtype))
+    cublas_compute_type = _get_compute_type(dtype, compute_type)
+
+    alpha = np.array(alpha, dtype=dtype)
+    beta = np.array(beta, dtype=dtype)
+
+    # potential copy is needed to ensure correct memory layout
+    # TODO: no memory copy, but correct strides
+    a = cp.ascontiguousarray(a, dtype=dtype)
+    b = cp.ascontiguousarray(b, dtype=dtype)
+
+    batchsize = np.prod(batchshape)
+
+    # allocate c if not provided
+    return_c = False
+    if c is None:
+        return_c = True
+        c = xp.empty((*batchshape, m, n), dtype=dtype)
+
+    if m == 0 or n == 0 or k == 0 or batchsize == 0:
+        return c
+
+    # potential copy is needed to ensure correct memory layout
+    # and to avoid memory corruption
+    is_contiguous = c.flags["C_CONTIGUOUS"] or c.flags["F_CONTIGUOUS"]
+    is_fortran_order = c.flags["F_CONTIGUOUS"]
+    if not return_c and (is_fortran_order or not is_contiguous):
+        original_c = c
+        c = cp.ascontiguousarray(c, dtype=dtype)
+
+    handle = device.get_cublas_handle()
+
+    cublas.gemmStridedBatchedEx(
+        handle,
+        cublas.CUBLAS_OP_N,
+        cublas.CUBLAS_OP_N,
+        n,
+        m,
+        k,
+        alpha.ctypes.data,
+        b.data.ptr,
+        cublas_type,
+        n,
+        n * k,
+        a.data.ptr,
+        cublas_type,
+        k,
+        m * k,
+        beta.ctypes.data,
+        c.data.ptr,
+        cublas_type,
+        n,
+        n * m,
+        batchsize,
+        cublas_compute_type,
+        cublas.CUBLAS_GEMM_DEFAULT,
+    )
+
+    if return_c:
+        return c
+    elif is_fortran_order or not is_contiguous:
+        original_c[:] = c

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -3,6 +3,8 @@
 import numba as nb
 import pytest
 
+from qttools import xp
+
 nb.set_num_threads(1)
 
 NUM_INDS = [
@@ -35,6 +37,41 @@ BLOCK_COORDS = [
     pytest.param((3, 4), id="20x20"),
 ]
 
+M_N_K = [
+    pytest.param((10, 10, 10), id="100x100x100"),
+    pytest.param((20, 10, 10), id="200x100x100"),
+    pytest.param((10, 20, 10), id="100x200x100"),
+    pytest.param((10, 10, 20), id="100x100x200"),
+    pytest.param((10, 10, 20), id="200x200x100"),
+]
+
+BATCHSHAPE = [
+    pytest.param((1,), id="1"),
+    pytest.param((1, 1), id="1x1"),
+    pytest.param((3,), id="3"),
+    pytest.param((3, 2), id="3x2"),
+    pytest.param((11, 1), id="11x1"),
+    pytest.param((1, 11, 1), id="1x11x1"),
+]
+
+DTYPE_COMPUTE_TYPE = [
+    pytest.param((xp.float32, "32F"), id="32F 32F"),
+    pytest.param((xp.float64, "64F"), id="64F 64F"),
+    pytest.param((xp.complex64, "32F"), id="32C 32F"),
+    pytest.param((xp.complex128, "64F"), id="64C 64F"),
+    pytest.param((xp.float32, "16F"), id="32F 16F"),
+    pytest.param((xp.float32, "16BF"), id="32F 16BF"),
+    pytest.param((xp.float32, "32TF"), id="32F 32TF"),
+    pytest.param((xp.complex64, "16F"), id="32C 16F"),
+    pytest.param((xp.complex64, "16BF"), id="32C 16BF"),
+    pytest.param((xp.complex64, "32TF"), id="32C 32TF"),
+]
+
+ORDER = [
+    pytest.param("C", id="C"),
+    pytest.param("F", id="F"),
+]
+
 
 @pytest.fixture(params=NUM_INDS)
 def num_inds(request: pytest.FixtureRequest):
@@ -63,4 +100,24 @@ def num_blocks(request: pytest.FixtureRequest):
 
 @pytest.fixture(params=BLOCK_COORDS)
 def block_coords(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=M_N_K)
+def m_n_k(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=BATCHSHAPE)
+def batchshape(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=DTYPE_COMPUTE_TYPE)
+def dtype_compute_type(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=ORDER)
+def order(request: pytest.FixtureRequest):
     return request.param

--- a/tests/kernels/test_gemmEx.py
+++ b/tests/kernels/test_gemmEx.py
@@ -1,0 +1,406 @@
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from qttools import xp
+from qttools.kernels import gemm
+
+
+@pytest.mark.usefixtures("m_n_k", "dtype_compute_type", "order")
+def test_gemm(
+    m_n_k: Tuple[int, int, int], dtype_compute_type: Tuple[xp.dtype, str], order: str
+):
+    m, n, k = m_n_k
+    dtype, compute_type = dtype_compute_type
+    real_dtype = np.dtype(dtype).type(0).real.dtype
+
+    # certain compute types not allowed with numpy
+    if xp.__name__ == "numpy":
+        if compute_type in ["16F", "16BF", "32TF"]:
+            return
+
+    rng = xp.random.default_rng(seed=1)
+    if dtype in [xp.complex64, xp.complex128]:
+        a = rng.random((m, k), dtype=real_dtype) + 1j * rng.random(
+            (m, k), dtype=real_dtype
+        )
+        b = rng.random((k, n), dtype=real_dtype) + 1j * rng.random(
+            (k, n), dtype=real_dtype
+        )
+    elif dtype in [xp.float32, xp.float64]:
+        a = rng.random((m, k), dtype=real_dtype)
+        b = rng.random((k, n), dtype=real_dtype)
+    else:
+        raise ValueError("Invalid dtype")
+
+    if order == "F":
+        a = xp.asfortranarray(a)
+        b = xp.asfortranarray(b)
+    elif order == "C":
+        a = xp.ascontiguousarray(a)
+        b = xp.ascontiguousarray(b)
+    else:
+        raise ValueError("Invalid order")
+
+    a_copy = a.copy()
+    b_copy = b.copy()
+
+    alpha = np.random.randn(1)[0]
+
+    c = gemm(a, b, alpha=alpha, compute_type=compute_type)
+
+    c_ref = alpha * a @ b
+
+    # NOTE: tolerance needs to be quite high for float32 and complex64
+    if dtype in [xp.float32, xp.complex64]:
+        reltol = 1e-6
+    else:
+        reltol = 1e-14
+
+    assert xp.allclose(a, a_copy)
+    assert xp.allclose(b, b_copy)
+    assert xp.linalg.norm(c - c_ref) / xp.linalg.norm(c_ref) < reltol
+
+
+@pytest.mark.usefixtures("m_n_k", "dtype_compute_type", "order")
+def test_gemm_inplace(
+    m_n_k: Tuple[int, int, int], dtype_compute_type: Tuple[xp.dtype, str], order: str
+):
+    m, n, k = m_n_k
+    dtype, compute_type = dtype_compute_type
+    real_dtype = np.dtype(dtype).type(0).real.dtype
+
+    # certain compute types not allowed with numpy
+    if xp.__name__ == "numpy":
+        if compute_type in ["16F", "16BF", "32TF"]:
+            return
+
+    rng = xp.random.default_rng(seed=1)
+    if dtype in [xp.complex64, xp.complex128]:
+        a = rng.random((m, k), dtype=real_dtype) + 1j * rng.random(
+            (m, k), dtype=real_dtype
+        )
+        b = rng.random((k, n), dtype=real_dtype) + 1j * rng.random(
+            (k, n), dtype=real_dtype
+        )
+        c = rng.random((m, n), dtype=real_dtype) + 1j * rng.random(
+            (m, n), dtype=real_dtype
+        )
+    elif dtype in [xp.float32, xp.float64]:
+        a = rng.random((m, k), dtype=real_dtype)
+        b = rng.random((k, n), dtype=real_dtype)
+        c = rng.random((m, n), dtype=real_dtype)
+    else:
+        raise ValueError("Invalid dtype")
+
+    if order == "F":
+        a = xp.asfortranarray(a)
+        b = xp.asfortranarray(b)
+        c = xp.asfortranarray(c)
+    elif order == "C":
+        a = xp.ascontiguousarray(a)
+        b = xp.ascontiguousarray(b)
+        c = xp.ascontiguousarray(c)
+    else:
+        raise ValueError("Invalid order")
+
+    a_copy = a.copy()
+    b_copy = b.copy()
+    c_copy = c.copy()
+
+    alpha = np.random.randn(1)[0]
+    beta = np.random.randn(1)[0]
+
+    gemm(a, b, c=c, alpha=alpha, beta=beta, compute_type=compute_type)
+
+    c_ref = alpha * a @ b + beta * c_copy
+
+    # NOTE: tolerance needs to be quite high for float32 and complex64
+    if dtype in [xp.float32, xp.complex64]:
+        reltol = 1e-6
+    else:
+        reltol = 1e-14
+
+    assert xp.allclose(a, a_copy)
+    assert xp.allclose(b, b_copy)
+    assert xp.linalg.norm(c - c_ref) / xp.linalg.norm(c_ref) < reltol
+
+
+@pytest.mark.usefixtures("m_n_k", "dtype_compute_type", "order")
+def test_gemm_noncontiguous(
+    m_n_k: Tuple[int, int, int], dtype_compute_type: Tuple[xp.dtype, str], order: str
+):
+    m, n, k = m_n_k
+    dtype, compute_type = dtype_compute_type
+    real_dtype = np.dtype(dtype).type(0).real.dtype
+
+    # certain compute types not allowed with numpy
+    if xp.__name__ == "numpy":
+        if compute_type in ["16F", "16BF", "32TF"]:
+            return
+
+    rng = xp.random.default_rng(seed=1)
+    if dtype in [xp.complex64, xp.complex128]:
+        a = rng.random((2 * m, 2 * k), dtype=real_dtype) + 1j * rng.random(
+            (2 * m, 2 * k), dtype=real_dtype
+        )
+        b = rng.random((2 * k, 2 * n), dtype=real_dtype) + 1j * rng.random(
+            (2 * k, 2 * n), dtype=real_dtype
+        )
+        c = rng.random((2 * m, 2 * n), dtype=real_dtype) + 1j * rng.random(
+            (2 * m, 2 * n), dtype=real_dtype
+        )
+    elif dtype in [xp.float32, xp.float64]:
+        a = rng.random((2 * m, 2 * k), dtype=real_dtype)
+        b = rng.random((2 * k, 2 * n), dtype=real_dtype)
+        c = rng.random((2 * m, 2 * n), dtype=real_dtype)
+    else:
+        raise ValueError("Invalid dtype")
+
+    if order == "F":
+        a = xp.asfortranarray(a)
+        b = xp.asfortranarray(b)
+        c = xp.asfortranarray(c)
+    elif order == "C":
+        a = xp.ascontiguousarray(a)
+        b = xp.ascontiguousarray(b)
+        c = xp.ascontiguousarray(c)
+    else:
+        raise ValueError("Invalid order")
+
+    a_copy = a.copy()
+    b_copy = b.copy()
+    c_copy = c.copy()
+
+    alpha = np.random.randn(1)[0]
+    beta = np.random.randn(1)[0]
+
+    gemm(
+        a[:m, :k],
+        b[:k, :n],
+        c=c[:m, :n],
+        alpha=alpha,
+        beta=beta,
+        compute_type=compute_type,
+    )
+
+    c_ref = alpha * a[:m, :k] @ b[:k, :n] + beta * c_copy[:m, :n]
+
+    # NOTE: tolerance needs to be quite high for float32 and complex64
+    if dtype in [xp.float32, xp.complex64]:
+        reltol = 1e-6
+    else:
+        reltol = 1e-14
+
+    assert xp.allclose(a, a_copy)
+    assert xp.allclose(b, b_copy)
+    assert xp.linalg.norm(c[:m, :n] - c_ref) / xp.linalg.norm(c_ref) < reltol
+    assert xp.allclose(c[:m, n:], c_copy[:m, n:])
+    assert xp.allclose(c[m:, :n], c_copy[m:, :n])
+    assert xp.allclose(c[m:, n:], c_copy[m:, n:])
+
+
+@pytest.mark.usefixtures("m_n_k", "batchshape", "dtype_compute_type", "order")
+def test_gemm_batched(
+    m_n_k: Tuple[int, int, int],
+    batchshape: int,
+    dtype_compute_type: Tuple[xp.dtype, str],
+    order: str,
+):
+    m, n, k = m_n_k
+    dtype, compute_type = dtype_compute_type
+    real_dtype = np.dtype(dtype).type(0).real.dtype
+
+    # certain compute types not allowed with numpy
+    if xp.__name__ == "numpy":
+        if compute_type in ["16F", "16BF", "32TF"]:
+            return
+
+    rng = xp.random.default_rng(seed=1)
+    if dtype in [xp.complex64, xp.complex128]:
+        a = rng.random((*batchshape, m, k), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, m, k), dtype=real_dtype
+        )
+        b = rng.random((*batchshape, k, n), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, k, n), dtype=real_dtype
+        )
+    elif dtype in [xp.float32, xp.float64]:
+        a = rng.random((*batchshape, m, k), dtype=real_dtype)
+        b = rng.random((*batchshape, k, n), dtype=real_dtype)
+    else:
+        raise ValueError("Invalid dtype")
+
+    if order == "F":
+        a = xp.asfortranarray(a)
+        b = xp.asfortranarray(b)
+    elif order == "C":
+        a = xp.ascontiguousarray(a)
+        b = xp.ascontiguousarray(b)
+    else:
+        raise ValueError("Invalid order")
+
+    a_copy = a.copy()
+    b_copy = b.copy()
+
+    alpha = np.random.randn(1)[0]
+
+    c = gemm(a, b, alpha=alpha, compute_type=compute_type)
+
+    c_ref = alpha * a @ b
+    # NOTE: tolerance needs to be quite high for float32 and complex64
+    if dtype in [xp.float32, xp.complex64]:
+        reltol = 1e-6
+    else:
+        reltol = 1e-14
+
+    print(a.shape)
+    print(a_copy.shape)
+
+    assert xp.allclose(a, a_copy)
+    assert xp.allclose(b, b_copy)
+    assert xp.linalg.norm(c - c_ref) / xp.linalg.norm(c_ref) < reltol
+
+
+@pytest.mark.usefixtures("m_n_k", "batchshape", "dtype_compute_type", "order")
+def test_gemm_batched_inplace(
+    m_n_k: Tuple[int, int, int],
+    batchshape: Tuple[int],
+    dtype_compute_type: Tuple[xp.dtype, str],
+    order: str,
+):
+    m, n, k = m_n_k
+    dtype, compute_type = dtype_compute_type
+    real_dtype = np.dtype(dtype).type(0).real.dtype
+
+    # certain compute types not allowed with numpy
+    if xp.__name__ == "numpy":
+        if compute_type in ["16F", "16BF", "32TF"]:
+            return
+
+    rng = xp.random.default_rng(seed=1)
+    if dtype in [xp.complex64, xp.complex128]:
+        a = rng.random((*batchshape, m, k), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, m, k), dtype=real_dtype
+        )
+        b = rng.random((*batchshape, k, n), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, k, n), dtype=real_dtype
+        )
+        c = rng.random((*batchshape, m, n), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, m, n), dtype=real_dtype
+        )
+    elif dtype in [xp.float32, xp.float64]:
+        a = rng.random((*batchshape, m, k), dtype=real_dtype)
+        b = rng.random((*batchshape, k, n), dtype=real_dtype)
+        c = rng.random((*batchshape, m, n), dtype=real_dtype)
+    else:
+        raise ValueError("Invalid dtype")
+
+    if order == "F":
+        a = xp.asfortranarray(a)
+        b = xp.asfortranarray(b)
+        c = xp.asfortranarray(c)
+    elif order == "C":
+        a = xp.ascontiguousarray(a)
+        b = xp.ascontiguousarray(b)
+        c = xp.ascontiguousarray(c)
+    else:
+        raise ValueError("Invalid order")
+
+    a_copy = a.copy()
+    b_copy = b.copy()
+    c_copy = c.copy()
+
+    alpha = np.random.randn(1)[0]
+    beta = np.random.randn(1)[0]
+
+    gemm(a, b, c=c, alpha=alpha, beta=beta, compute_type=compute_type)
+
+    c_ref = alpha * a @ b + beta * c_copy
+
+    # NOTE: tolerance needs to be quite high for float32 and complex64
+    if dtype in [xp.float32, xp.complex64]:
+        reltol = 1e-6
+    else:
+        reltol = 1e-14
+
+    assert xp.allclose(a, a_copy)
+    assert xp.allclose(b, b_copy)
+    assert xp.linalg.norm(c - c_ref) / xp.linalg.norm(c_ref) < reltol
+
+
+@pytest.mark.usefixtures("m_n_k", "batchshape", "dtype_compute_type", "order")
+def test_gemm_batched_noncontiguous(
+    m_n_k: Tuple[int, int, int],
+    batchshape: Tuple[int],
+    dtype_compute_type: Tuple[xp.dtype, str],
+    order: str,
+):
+    m, n, k = m_n_k
+    dtype, compute_type = dtype_compute_type
+    real_dtype = np.dtype(dtype).type(0).real.dtype
+
+    # certain compute types not allowed with numpy
+    if xp.__name__ == "numpy":
+        if compute_type in ["16F", "16BF", "32TF"]:
+            return
+
+    rng = xp.random.default_rng(seed=1)
+    if dtype in [xp.complex64, xp.complex128]:
+        a = rng.random((*batchshape, 2 * m, 2 * k), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, 2 * m, 2 * k), dtype=real_dtype
+        )
+        b = rng.random((*batchshape, 2 * k, 2 * n), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, 2 * k, 2 * n), dtype=real_dtype
+        )
+        c = rng.random((*batchshape, 2 * m, 2 * n), dtype=real_dtype) + 1j * rng.random(
+            (*batchshape, 2 * m, 2 * n), dtype=real_dtype
+        )
+    elif dtype in [xp.float32, xp.float64]:
+        a = rng.random((*batchshape, 2 * m, 2 * k), dtype=real_dtype)
+        b = rng.random((*batchshape, 2 * k, 2 * n), dtype=real_dtype)
+        c = rng.random((*batchshape, 2 * m, 2 * n), dtype=real_dtype)
+    else:
+        raise ValueError("Invalid dtype")
+
+    if order == "F":
+        a = xp.asfortranarray(a)
+        b = xp.asfortranarray(b)
+        c = xp.asfortranarray(c)
+    elif order == "C":
+        a = xp.ascontiguousarray(a)
+        b = xp.ascontiguousarray(b)
+        c = xp.ascontiguousarray(c)
+    else:
+        raise ValueError("Invalid order")
+
+    a_copy = a.copy()
+    b_copy = b.copy()
+    c_copy = c.copy()
+
+    alpha = np.random.randn(1)[0]
+    beta = np.random.randn(1)[0]
+
+    gemm(
+        a[..., :m, :k],
+        b[..., :k, :n],
+        c=c[..., :m, :n],
+        alpha=alpha,
+        beta=beta,
+        compute_type=compute_type,
+    )
+
+    c_ref = alpha * a[..., :m, :k] @ b[..., :k, :n] + beta * c_copy[..., :m, :n]
+
+    # NOTE: tolerance needs to be quite high for float32 and complex64
+    if dtype in [xp.float32, xp.complex64]:
+        reltol = 1e-6
+    else:
+        reltol = 1e-14
+
+    assert xp.allclose(a, a_copy)
+    assert xp.allclose(b, b_copy)
+    assert xp.linalg.norm(c[..., :m, :n] - c_ref) / xp.linalg.norm(c_ref) < reltol
+    assert xp.allclose(c[..., :m, n:], c_copy[..., :m, n:])
+    assert xp.allclose(c[..., m:, :n], c_copy[..., m:, :n])
+    assert xp.allclose(c[..., m:, n:], c_copy[..., m:, n:])


### PR DESCRIPTION
The low-level call [gemmEx](https://docs.nvidia.com/cuda/cublas/#cublas-t-gemmex) and [gemmBatchedEx ](https://docs.nvidia.com/cuda/cublas/#cublasgemmstridedbatchedex) are exposed by cupy, but no Pythonic wrapper is provided
This request implements such a wrapper and tests for it.

- fp32 and fp64 inputs and outputs with different intermediate datatypes are supported. 
- It is possible to extend for fp16, but accumulating in higher precision with low precision output is not available.
- The wrapper is agnostic, if numpy is used then no special datatypes are available and the gemm is done naively.
- Calls ascontiguous and thus can incur a memory copy. This follows the style of cupy [_batched_inv](https://github.com/cupy/cupy/blob/9ec2184716a2dc05c3e11d856a981d061dd563bf/cupy/linalg/_solve.py#L256)