### PR TITLE
Enables cp.linalg.eig to be used if available

### DIFF
--- a/src/qttools/kernels/__init__.py
+++ b/src/qttools/kernels/__init__.py
@@ -16,6 +16,7 @@ else:
     raise ValueError(f"Unrecognized ARRAY_MODULE '{xp.__name__}'")
 
 import qttools.kernels.operator as operator
+import qttools.kernels.eig as eig
 
 __all__ = [
     "dsbsparse_kernels",
@@ -23,4 +24,5 @@ __all__ = [
     "dsbcsr_kernels",
     "obc_kernels",
     "operator",
+    "eig",
 ]

--- a/src/qttools/kernels/__init__.py
+++ b/src/qttools/kernels/__init__.py
@@ -17,6 +17,7 @@ else:
 
 import qttools.kernels.operator as operator
 import qttools.kernels.eig as eig
+import qttools.kernels.eigvalsh as eigvalsh
 import qttools.kernels.svd as svd
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "operator",
     "eig",
     "svd",
+    "eigvalsh",
 ]

--- a/src/qttools/kernels/__init__.py
+++ b/src/qttools/kernels/__init__.py
@@ -17,6 +17,7 @@ else:
 
 import qttools.kernels.operator as operator
 import qttools.kernels.eig as eig
+import qttools.kernels.svd as svd
 
 __all__ = [
     "dsbsparse_kernels",
@@ -24,4 +25,5 @@ __all__ = [
     "dsbcsr_kernels",
     "operator",
     "eig",
+    "svd",
 ]

--- a/src/qttools/kernels/__init__.py
+++ b/src/qttools/kernels/__init__.py
@@ -22,7 +22,6 @@ __all__ = [
     "dsbsparse_kernels",
     "dsbcoo_kernels",
     "dsbcsr_kernels",
-    "obc_kernels",
     "operator",
     "eig",
 ]

--- a/src/qttools/kernels/eig.py
+++ b/src/qttools/kernels/eig.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
+
+import numpy as np
+
+from qttools import NDArray, xp
+from qttools.utils.gpu_utils import get_device, get_host
+
+
+def eig(A: NDArray, compute_location: str = "host") -> tuple[NDArray, NDArray]:
+    """Computes the eigenvalues and eigenvectors of a matrix on a given location.
+
+    The variable compute_location has no effect if numpy is used.
+    To compute the eigenvalues and eigenvectors on the device with cupy
+    is only possible if the cupy.linalg.eig function is available.
+
+    Parameters
+    ----------
+    A : NDArray
+        The matrix.
+    compute_location : str, optional
+        The location where to compute the eigenvalues and eigenvectors.
+        Can be either "device" or "host".
+
+    Returns
+    -------
+    NDArray
+        The eigenvalues.
+    NDArray
+        The eigenvectors.
+
+    """
+
+    if (
+        compute_location == "device"
+        and xp.__name__ == "cupy"
+        and hasattr(xp.linalg, "eig")
+    ):
+        w, v = xp.linalg.eig(A)
+    elif compute_location == "host":
+        A = get_host(A)
+        w, v = np.linalg.eig(A)
+        w, v = get_device(w), get_device(v)
+    else:
+        raise ValueError(f"Invalid compute location: {compute_location}")
+
+    return w, v

--- a/src/qttools/kernels/eig.py
+++ b/src/qttools/kernels/eig.py
@@ -3,13 +3,16 @@
 import numpy as np
 
 from qttools import NDArray, xp
-from qttools.utils.gpu_utils import get_device, get_host
+from qttools.utils.gpu_utils import get_array_module_name, get_device, get_host
 
 
-def eig(A: NDArray, compute_location: str = "host") -> tuple[NDArray, NDArray]:
+def eig(
+    A: NDArray,
+    compute_module: str = "numpy",
+    output_module: str | None = None,
+) -> tuple[NDArray, NDArray]:
     """Computes the eigenvalues and eigenvectors of a matrix on a given location.
 
-    The variable compute_location has no effect if numpy is used.
     To compute the eigenvalues and eigenvectors on the device with cupy
     is only possible if the cupy.linalg.eig function is available.
 
@@ -17,9 +20,13 @@ def eig(A: NDArray, compute_location: str = "host") -> tuple[NDArray, NDArray]:
     ----------
     A : NDArray
         The matrix.
-    compute_location : str, optional
+    compute_module : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "device" or "host".
+        Can be either "numpy" or "cupy".
+    output_module : str, optional
+        The location where to store the eigenvalues and eigenvectors.
+        Can be either "numpy"
+        or "cupy". If None, the output location is the same as the input location
 
     Returns
     -------
@@ -29,18 +36,40 @@ def eig(A: NDArray, compute_location: str = "host") -> tuple[NDArray, NDArray]:
         The eigenvectors.
 
     """
+    input_module = get_array_module_name(A)
 
-    if (
-        compute_location == "device"
-        and xp.__name__ == "cupy"
-        and hasattr(xp.linalg, "eig")
+    if output_module is None:
+        output_module = input_module
+
+    if output_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid output location: {output_module}")
+    if compute_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid compute location: {compute_module}")
+    if input_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid input location: {input_module}")
+
+    if compute_module == "cupy" and hasattr(xp.linalg, "eig") is False:
+        raise ValueError("Eig is not available in cupy.")
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
     ):
-        w, v = xp.linalg.eig(A)
-    elif compute_location == "host":
+        raise ValueError("Cannot do gpu computation with numpy as xp.")
+
+    # memcopy to correct location
+    if compute_module == "numpy" and input_module == "cupy":
         A = get_host(A)
+    elif compute_module == "cupy" and input_module == "numpy":
+        A = get_device(A)
+
+    if compute_module == "cupy":
+        w, v = xp.linalg.eig(A)
+    elif compute_module == "numpy":
         w, v = np.linalg.eig(A)
+
+    if output_module == "numpy" and compute_module == "cupy":
+        w, v = get_host(w), get_host(v)
+    elif output_module == "cupy" and compute_module == "numpy":
         w, v = get_device(w), get_device(v)
-    else:
-        raise ValueError(f"Invalid compute location: {compute_location}")
 
     return w, v

--- a/src/qttools/kernels/eigvalsh.py
+++ b/src/qttools/kernels/eigvalsh.py
@@ -1,0 +1,112 @@
+import numpy as np
+
+from qttools import NDArray, xp
+from qttools.utils.gpu_utils import get_array_module_name, get_device, get_host
+
+
+def _eigvalsh(
+    A: NDArray,
+    B: NDArray,
+    xp_eigvalsh: xp,
+) -> NDArray:
+    """Compute eigenvalues of a hermitain generalized eigenvalue problem.
+
+    Parameters
+    ----------
+    A : NDArray
+        A complex or real symmetric or hermitian matrix.
+    B : NDArray
+        A complex or real symmetric or hermitian positive definite matrix.
+    xp_eigvalsh : module
+        The location where to compute the eigenvalues.
+
+    Returns
+    -------
+    NDArray
+        The eigenvalues of the generalized eigenvalue problem.
+
+    """
+
+    R = xp_eigvalsh.linalg.cholesky(B)
+
+    # NOTE: would be more efficient to use cholesky_solve
+    # if it would be supported by cupy
+    R_inv = xp_eigvalsh.linalg.inv(R)
+    A_hat = R_inv @ A @ R_inv.swapaxes(-2, -1).conj()
+    w = xp_eigvalsh.linalg.eigvalsh(A_hat)
+
+    return w
+
+
+def eigvalsh(
+    A: NDArray,
+    B: NDArray | None = None,
+    compute_module: str = "cupy",
+    output_module: str | None = None,
+) -> NDArray:
+    """Compute eigenvalues of a hermitain generalized eigenvalue problem.
+
+    TODO: only type 1 generalized problems are supported,
+    Only a subset of keywords of scipy.linalg.eigvalsh are supported.
+
+    Parameters
+    ----------
+    A : NDArray
+        A complex or real symmetric or hermitian matrix.
+    B : NDArray, optional
+        A complex or real symmetric or hermitian positive definite matrix.
+        If omitted, identity matrix is assumed.
+    compute_module : str, optional
+        The location where to compute the eigenvalues.
+    output_module : str, optional
+        The location where to store the resulting eigenvalues.
+
+    Returns
+    -------
+    NDArray
+        The eigenvalues of the generalized eigenvalue problem.
+
+    """
+    input_module = get_array_module_name(A)
+
+    if B is not None and input_module != get_array_module_name(B):
+        raise ValueError("Input arrays must be at the same location.")
+
+    if output_module is None:
+        output_module = input_module
+
+    if output_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid output location: {output_module}")
+    if compute_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid compute location: {compute_module}")
+    if input_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid input location: {input_module}")
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        raise ValueError("Cannot do gpu computation with numpy as xp.")
+
+    # memcopy to correct location
+    if compute_module == "numpy" and input_module == "cupy":
+        A = get_host(A)
+    elif compute_module == "cupy" and input_module == "numpy":
+        A = get_device(A)
+
+    if B is None:
+        if compute_module == "numpy":
+            w = np.linalg.eigvalsh(A)
+        elif compute_module == "cupy":
+            w = xp.linalg.eigvalsh(A)
+    else:
+        if compute_module == "numpy":
+            w = _eigvalsh(A, B, np)
+        elif compute_module == "cupy":
+            w = _eigvalsh(A, B, xp)
+
+    if output_module == "numpy" and compute_module == "cupy":
+        w = get_host(w)
+    elif output_module == "cupy" and compute_module == "numpy":
+        w = get_device(w)
+
+    return w

--- a/src/qttools/kernels/svd.py
+++ b/src/qttools/kernels/svd.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
+
+import numpy as np
+
+from qttools import NDArray, xp
+from qttools.utils.gpu_utils import get_array_module_name, get_device, get_host
+
+
+def svd(
+    A: NDArray,
+    full_matrices: bool = True,
+    compute_uv: bool = True,
+    compute_module: str = "numpy",
+    output_module: str | None = None,
+) -> tuple[NDArray, NDArray, NDArray]:
+    """Computes the singular value decomposition of a matrix on a given location.
+
+    Parameters
+    ----------
+    A : NDArray
+        The matrix.
+    compute_module : str, optional
+        The location where to compute the singular value decomposition.
+        Can be either "numpy" or "cupy".
+    output_module : str, optional
+        The location where to store the singular value decomposition.
+        Can be either "numpy"
+        or "cupy". If None, the output location is the same as the input location
+
+    Returns
+    -------
+    NDArray
+        The left singular vectors.
+    NDArray
+        The singular values.
+    NDArray
+        The right singular vectors.
+
+    """
+    input_module = get_array_module_name(A)
+
+    if output_module is None:
+        output_module = input_module
+
+    if output_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid output location: {output_module}")
+    if compute_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid compute location: {compute_module}")
+    if input_module not in ["numpy", "cupy"]:
+        raise ValueError(f"Invalid input location: {input_module}")
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        raise ValueError("Cannot do gpu computation with numpy as xp.")
+
+    # memcopy to correct location
+    if compute_module == "numpy" and input_module == "cupy":
+        A = get_host(A)
+    elif compute_module == "cupy" and input_module == "numpy":
+        A = get_device(A)
+
+    if compute_module == "cupy":
+        u, s, vh = xp.linalg.svd(A, full_matrices=full_matrices, compute_uv=compute_uv)
+    elif compute_module == "numpy":
+        u, s, vh = np.linalg.svd(A, full_matrices=full_matrices, compute_uv=compute_uv)
+
+    if output_module == "numpy" and compute_module == "cupy":
+        u, s, vh = get_host(u), get_host(s), get_host(vh)
+    elif output_module == "cupy" and compute_module == "numpy":
+        u, s, vh = get_device(u), get_device(s), get_device(vh)
+
+    return u, s, vh

--- a/src/qttools/lyapunov/spectral.py
+++ b/src/qttools/lyapunov/spectral.py
@@ -18,7 +18,7 @@ class Spectral(LyapunovSolver):
         The threshold for the relative recursion error to issue a warning.
     eig_compute_location : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "device" or "host". Only relevant if cupy is used.
+        Can be either "numpy" or "cupy". Only relevant if cupy is used.
 
     """
 
@@ -26,7 +26,7 @@ class Spectral(LyapunovSolver):
         self,
         num_ref_iterations: int = 3,
         warning_threshold: float = 1e-1,
-        eig_compute_location: str = "host",
+        eig_compute_location: str = "numpy",
     ) -> None:
         """Initializes the spectral Lyapunov solver."""
         self.num_ref_iterations = num_ref_iterations
@@ -65,7 +65,7 @@ class Spectral(LyapunovSolver):
             a = a[xp.newaxis, ...]
             q = q[xp.newaxis, ...]
 
-        ws, vs = eig(a, compute_location=self.eig_compute_location)
+        ws, vs = eig(a, compute_module=self.eig_compute_location)
 
         inv_vs = xp.linalg.inv(vs)
         gamma = inv_vs @ q @ inv_vs.conj().swapaxes(-1, -2)

--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -35,7 +35,7 @@ class Beyn(NEVP):
         Only relevant for GPU computations.
     eig_compute_location : str, optional
         The location where to compute the eigenvalues and eigenvectors.
-        Can be either "device" or "host". Only relevant if cupy is used.
+        Can be either "numpy" or "cupy". Only relevant if cupy is used.
 
     """
 
@@ -46,7 +46,7 @@ class Beyn(NEVP):
         m_0: int,
         num_quad_points: int,
         num_threads_contour: int = 1024,
-        eig_compute_location: str = "host",
+        eig_compute_location: str = "numpy",
     ):
         """Initializes the Beyn NEVP solver."""
         self.r_o = r_o
@@ -131,7 +131,7 @@ class Beyn(NEVP):
 
             # Probe second moment.
             a = u.conj().T @ P_1[i] @ vh.conj().T / s
-            w, v = eig(a, compute_location=self.eig_compute_location)
+            w, v = eig(a, compute_module=self.eig_compute_location)
 
             # Recover the full eigenvectors from the subspace.
             ws[i, : len(inds)] = w
@@ -243,8 +243,8 @@ class Beyn(NEVP):
             # NOTE: xp.diag is unnecessary, should be removed
             a_hat = xp.diag(1 / s_hat) @ u_hat.conj().T @ P_1_hat[i] @ vh_hat.conj().T
 
-            w, v = eig(a, compute_location=self.eig_compute_location)
-            w_hat, v_hat = eig(a_hat, compute_location=self.eig_compute_location)
+            w, v = eig(a, compute_module=self.eig_compute_location)
+            w_hat, v_hat = eig(a_hat, compute_module=self.eig_compute_location)
 
             # Recover the full eigenvectors from the subspace.
             wrs[i, : len(inds)] = w

--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2024 ETH Zurich and the authors of the qttools package.
 
-import numpy as np
-
 from qttools import NDArray, xp
+from qttools.kernels.eig import eig
 from qttools.kernels.operator import operator_inverse
 from qttools.nevp.nevp import NEVP
-from qttools.utils.gpu_utils import get_device, get_host
 
 rng = xp.random.default_rng(42)
 
@@ -35,6 +33,9 @@ class Beyn(NEVP):
     num_threads_contour : int, optional
         The number of cuda threads to use for the contour integration kernel.
         Only relevant for GPU computations.
+    eig_compute_location : str, optional
+        The location where to compute the eigenvalues and eigenvectors.
+        Can be either "device" or "host". Only relevant if cupy is used.
 
     """
 
@@ -45,6 +46,7 @@ class Beyn(NEVP):
         m_0: int,
         num_quad_points: int,
         num_threads_contour: int = 1024,
+        eig_compute_location: str = "host",
     ):
         """Initializes the Beyn NEVP solver."""
         self.r_o = r_o
@@ -52,6 +54,7 @@ class Beyn(NEVP):
         self.m_0 = m_0
         self.num_quad_points = num_quad_points
         self.num_threads_contour = num_threads_contour
+        self.eig_compute_location = eig_compute_location
 
     def _one_sided(self, a_xx: tuple[NDArray, ...]) -> tuple[NDArray, NDArray]:
         """Solves the plynomial eigenvalue problem.
@@ -126,13 +129,13 @@ class Beyn(NEVP):
 
             u, s, vh = u[:, inds], s[inds], vh[inds, :]
 
-            # Probe second moment. No eigenvalues on the GPU :(
-            a = get_host(u.conj().T @ P_1[i] @ vh.conj().T / s)
-            w, v = np.linalg.eig(a)
+            # Probe second moment.
+            a = u.conj().T @ P_1[i] @ vh.conj().T / s
+            w, v = eig(a, compute_location=self.eig_compute_location)
 
             # Recover the full eigenvectors from the subspace.
-            ws[i, : len(inds)] = get_device(w)
-            vs[i, :, : len(inds)] = u @ get_device(v)
+            ws[i, : len(inds)] = w
+            vs[i, :, : len(inds)] = u @ v
 
         return ws, vs
 
@@ -236,20 +239,17 @@ class Beyn(NEVP):
             )
 
             # Probe second moment.
-            a = get_host(u.conj().T @ P_1[i] @ vh.conj().T / s)
+            a = u.conj().T @ P_1[i] @ vh.conj().T / s
             # NOTE: xp.diag is unnecessary, should be removed
-            a_hat = get_host(
-                xp.diag(1 / s_hat) @ u_hat.conj().T @ P_1_hat[i] @ vh_hat.conj().T
-            )
+            a_hat = xp.diag(1 / s_hat) @ u_hat.conj().T @ P_1_hat[i] @ vh_hat.conj().T
 
-            w, v = np.linalg.eig(a)
-            w_hat, v_hat = np.linalg.eig(a_hat)
+            w, v = eig(a, compute_location=self.eig_compute_location)
+            w_hat, v_hat = eig(a_hat, compute_location=self.eig_compute_location)
 
             # Recover the full eigenvectors from the subspace.
-            wrs[i, : len(inds)] = get_device(w)
-            wls[i, : len(inds_hat)] = get_device(w_hat)
+            wrs[i, : len(inds)] = w
+            wls[i, : len(inds_hat)] = w_hat
 
-            v, v_hat = get_device(v), get_device(v_hat)
             vrs[i, :, : len(inds)] = u @ v
             vls[i, :, : len(inds_hat)] = xp.linalg.solve(v_hat, vh_hat).conj().T
 

--- a/src/qttools/nevp/full.py
+++ b/src/qttools/nevp/full.py
@@ -22,7 +22,7 @@ class Full(NEVP):
     """
 
     def _solve(
-        self, a_xx: tuple[NDArray, ...], eig_compute_location: str = "host"
+        self, a_xx: tuple[NDArray, ...], eig_compute_location: str = "numpy"
     ) -> tuple[NDArray, NDArray]:
         """Solves the plynomial eigenvalue problem.
 
@@ -36,7 +36,7 @@ class Full(NEVP):
             from lowest to highest order.
         eig_compute_location : str, optional
             The location where to compute the eigenvalues and eigenvectors.
-            Can be either "device" or "host". Only relevant if cupy is used.
+            Can be either "numpy" or "cupy". Only relevant if cupy is used.
 
         Returns
         -------
@@ -58,7 +58,7 @@ class Full(NEVP):
         B = xp.kron(xp.tri(len(a_xx) - 2).T, xp.eye(a_xx[0].shape[-1]))
         A[:, : B.shape[0], : B.shape[1]] -= B
 
-        w, v = eig(A, compute_location=eig_compute_location)
+        w, v = eig(A, compute_module=eig_compute_location)
 
         # Recover the original eigenvalues from the spectral transform.
         w = xp.where((xp.abs(w) == 0.0), -1.0, w)
@@ -71,7 +71,7 @@ class Full(NEVP):
         self,
         a_xx: tuple[NDArray, ...],
         left: bool = False,
-        eig_compute_location: str = "host",
+        eig_compute_location: str = "numpy",
     ) -> tuple:
         """Solves the plynomial eigenvalue problem.
 
@@ -87,7 +87,7 @@ class Full(NEVP):
             Whether to solve additionally for the left eigenvectors.
         eig_compute_location : str, optional
             The location where to compute the eigenvalues and eigenvectors.
-            Can be either "device" or "host". Only relevant if cupy is used.
+            Can be either "cupy" or "numpy". Only relevant if cupy is used.
 
         Returns
         -------

--- a/src/qttools/obc/obc.py
+++ b/src/qttools/obc/obc.py
@@ -70,7 +70,7 @@ class OBCMemoizer:
     def __init__(
         self,
         obc_solver: "OBCSolver",
-        num_ref_iterations: int = 2,
+        num_ref_iterations: int = 3,
         convergence_tol: float = 1e-4,
     ) -> None:
         """Initalizes the memoizer."""
@@ -162,7 +162,7 @@ class OBCMemoizer:
         x_ii_ref = xp.linalg.inv(a_ii - a_ji @ x_ii @ a_ij)
 
         # Check for convergence accross all MPI ranks.
-        recursion_error = xp.mean(
+        recursion_error = xp.max(
             xp.linalg.norm(x_ii_ref - x_ii, axis=(-2, -1))
             / xp.linalg.norm(x_ii_ref, axis=(-2, -1))
         )

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -40,7 +40,11 @@ BATCHSIZE = [
     pytest.param(3, id="3"),
 ]
 
-MATRIX_SIZE = [
+N = [
+    pytest.param(5, id="5"),
+    pytest.param(10, id="10"),
+]
+M = [
     pytest.param(5, id="5"),
     pytest.param(10, id="10"),
 ]
@@ -63,6 +67,11 @@ OUTPUT_MODULE = [
 INPUT_MODULE = [
     pytest.param("numpy", id="numpy"),
     pytest.param("cupy", id="cupy"),
+]
+
+FULL_MATRICES = [
+    pytest.param(True, id="True"),
+    pytest.param(False, id="False"),
 ]
 
 
@@ -106,8 +115,18 @@ def num_quatrature_points(request: pytest.FixtureRequest):
     return request.param
 
 
-@pytest.fixture(params=MATRIX_SIZE)
-def matrix_size(request: pytest.FixtureRequest):
+@pytest.fixture(params=N)
+def n(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=M)
+def m(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=FULL_MATRICES)
+def full_matrices(request: pytest.FixtureRequest):
     return request.param
 
 

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -44,6 +44,7 @@ N = [
     pytest.param(5, id="5"),
     pytest.param(10, id="10"),
 ]
+
 M = [
     pytest.param(5, id="5"),
     pytest.param(10, id="10"),
@@ -52,6 +53,13 @@ M = [
 NUM_QUATRATURE_POINTS = [
     pytest.param(5, id="5"),
     pytest.param(10, id="10"),
+]
+
+BATCH_SHAPE = [
+    pytest.param((1,), id="1"),
+    pytest.param((3,), id="1"),
+    pytest.param((5, 1), id="5x1"),
+    pytest.param((5, 2), id="5x2"),
 ]
 
 COMPUTE_MODULE = [
@@ -122,6 +130,11 @@ def n(request: pytest.FixtureRequest):
 
 @pytest.fixture(params=M)
 def m(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=BATCH_SHAPE)
+def batch_shape(request: pytest.FixtureRequest):
     return request.param
 
 

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -40,7 +40,7 @@ BATCHSIZE = [
     pytest.param(3, id="3"),
 ]
 
-BLOCKSIZE = [
+MATRIX_SIZE = [
     pytest.param(5, id="5"),
     pytest.param(10, id="10"),
 ]
@@ -48,6 +48,21 @@ BLOCKSIZE = [
 NUM_QUATRATURE_POINTS = [
     pytest.param(5, id="5"),
     pytest.param(10, id="10"),
+]
+
+COMPUTE_MODULE = [
+    pytest.param("numpy", id="numpy"),
+    pytest.param("cupy", id="cupy"),
+]
+
+OUTPUT_MODULE = [
+    pytest.param("numpy", id="numpy"),
+    pytest.param("cupy", id="cupy"),
+]
+
+INPUT_MODULE = [
+    pytest.param("numpy", id="numpy"),
+    pytest.param("cupy", id="cupy"),
 ]
 
 
@@ -86,11 +101,26 @@ def batchsize(request: pytest.FixtureRequest):
     return request.param
 
 
-@pytest.fixture(params=BLOCKSIZE)
-def blocksize(request: pytest.FixtureRequest):
+@pytest.fixture(params=NUM_QUATRATURE_POINTS)
+def num_quatrature_points(request: pytest.FixtureRequest):
     return request.param
 
 
-@pytest.fixture(params=NUM_QUATRATURE_POINTS)
-def num_quatrature_points(request: pytest.FixtureRequest):
+@pytest.fixture(params=MATRIX_SIZE)
+def matrix_size(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=COMPUTE_MODULE)
+def compute_module(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=OUTPUT_MODULE)
+def output_module(request: pytest.FixtureRequest):
+    return request.param
+
+
+@pytest.fixture(params=INPUT_MODULE)
+def input_module(request: pytest.FixtureRequest):
     return request.param

--- a/tests/kernels/test_eig.py
+++ b/tests/kernels/test_eig.py
@@ -9,12 +9,8 @@ if xp.__name__ == "cupy":
     import cupy as cp
 
 
-@pytest.mark.usefixtures(
-    "matrix_size", "compute_module", "input_module", "output_module"
-)
-def test_eig(
-    matrix_size: int, compute_module: str, input_module: str, output_module: str
-):
+@pytest.mark.usefixtures("n", "compute_module", "input_module", "output_module")
+def test_eig(n: int, compute_module: str, input_module: str, output_module: str):
     """Tests the eig function."""
 
     if xp.__name__ == "numpy" and (
@@ -29,7 +25,7 @@ def test_eig(
     elif input_module == "numpy":
         rng = np.random.default_rng()
 
-    A = rng.random((matrix_size, matrix_size))
+    A = rng.random((n, n)) + 1j * rng.random((n, n))
 
     w, v = eig(A, compute_module=compute_module, output_module=output_module)
 
@@ -38,5 +34,5 @@ def test_eig(
     v = get_host(v)
     A = get_host(A)
 
-    for i in range(matrix_size):
+    for i in range(n):
         assert xp.allclose(A @ v[:, i], w[i] * v[:, i])

--- a/tests/kernels/test_eig.py
+++ b/tests/kernels/test_eig.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+from qttools import xp
+from qttools.kernels.eig import eig
+from qttools.utils.gpu_utils import get_host
+
+if xp.__name__ == "cupy":
+    import cupy as cp
+
+
+@pytest.mark.usefixtures(
+    "matrix_size", "compute_module", "input_module", "output_module"
+)
+def test_eig(
+    matrix_size: int, compute_module: str, input_module: str, output_module: str
+):
+    """Tests the eig function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+    if xp.__name__ == "cupy" and (hasattr(xp.linalg, "eig") is False):
+        return
+
+    if input_module == "cupy":
+        rng = cp.random.default_rng()
+    elif input_module == "numpy":
+        rng = np.random.default_rng()
+
+    A = rng.random((matrix_size, matrix_size))
+
+    w, v = eig(A, compute_module=compute_module, output_module=output_module)
+
+    # check residual on the host
+    w = get_host(w)
+    v = get_host(v)
+    A = get_host(A)
+
+    for i in range(matrix_size):
+        assert xp.allclose(A @ v[:, i], w[i] * v[:, i])

--- a/tests/kernels/test_eig.py
+++ b/tests/kernels/test_eig.py
@@ -36,3 +36,53 @@ def test_eig(n: int, compute_module: str, input_module: str, output_module: str)
 
     for i in range(n):
         assert xp.allclose(A @ v[:, i], w[i] * v[:, i])
+
+
+@pytest.mark.usefixtures(
+    "n", "batch_shape", "compute_module", "input_module", "output_module"
+)
+def test_eig_batched(
+    n: int,
+    batch_shape: tuple[int, ...],
+    compute_module: str,
+    input_module: str,
+    output_module: str,
+):
+    """Tests the eig function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+    if xp.__name__ == "cupy" and (hasattr(xp.linalg, "eig") is False):
+        return
+
+    if input_module == "cupy":
+        rng = cp.random.default_rng()
+    elif input_module == "numpy":
+        rng = np.random.default_rng()
+
+    A = rng.random((*batch_shape, n, n)) + 1j * rng.random((*batch_shape, n, n))
+
+    w, v = eig(A, compute_module=compute_module, output_module=output_module)
+
+    assert w.shape[:-1] == batch_shape
+    assert v.shape[:-2] == batch_shape
+
+    assert w.shape[-1] == n
+    assert v.shape[-2] == n
+    assert v.shape[-1] == n
+
+    # check residual on the host
+    w = get_host(w)
+    v = get_host(v)
+    A = get_host(A)
+
+    batch_size = np.prod(batch_shape)
+    w = w.reshape(batch_size, n)
+    v = v.reshape(batch_size, n, n)
+    A = A.reshape(batch_size, n, n)
+
+    for j in range(batch_size):
+        for i in range(n):
+            assert xp.allclose(A[j] @ v[j, :, i], w[j, i] * v[j, :, i])

--- a/tests/kernels/test_eig.py
+++ b/tests/kernels/test_eig.py
@@ -17,7 +17,7 @@ def test_eig(n: int, compute_module: str, input_module: str, output_module: str)
         compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
     ):
         return
-    if xp.__name__ == "cupy" and (hasattr(xp.linalg, "eig") is False):
+    if compute_module == "cupy" and (hasattr(xp.linalg, "eig") is False):
         return
 
     if input_module == "cupy":
@@ -54,7 +54,7 @@ def test_eig_batched(
         compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
     ):
         return
-    if xp.__name__ == "cupy" and (hasattr(xp.linalg, "eig") is False):
+    if compute_module == "cupy" and (hasattr(xp.linalg, "eig") is False):
         return
 
     if input_module == "cupy":

--- a/tests/kernels/test_eigvalsh.py
+++ b/tests/kernels/test_eigvalsh.py
@@ -1,0 +1,189 @@
+import numpy as np
+import pytest
+import scipy
+
+from qttools import xp
+from qttools.kernels.eigvalsh import eigvalsh
+from qttools.utils.gpu_utils import get_device, get_host
+
+
+@pytest.mark.usefixtures("n", "compute_module", "input_module", "output_module")
+def test_eigvalsh(n: int, compute_module: str, input_module: str, output_module: str):
+    """Tests the eig function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+
+    rng = np.random.default_rng()
+
+    A = rng.random((n, n)) + 1j * rng.random((n, n))
+
+    A = (A + A.conj().swapaxes(-1, -2)) / 2
+
+    if compute_module == "cupy":
+        A = get_device(A)
+
+    w = eigvalsh(A, compute_module=compute_module, output_module=output_module)
+
+    # check residual on the host
+    w = get_host(w)
+    A = get_host(A)
+
+    w_ref = scipy.linalg.eigvalsh(A)
+
+    w = np.sort(w)
+    w_ref = np.sort(w_ref)
+
+    assert xp.allclose(w, w_ref)
+
+
+@pytest.mark.usefixtures(
+    "n", "batch_shape", "compute_module", "input_module", "output_module"
+)
+def test_eigvalsh_batched(
+    n: int,
+    batch_shape: tuple[int, ...],
+    compute_module: str,
+    input_module: str,
+    output_module: str,
+):
+    """Tests the eig function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+
+    rng = np.random.default_rng()
+
+    A = rng.random((*batch_shape, n, n)) + 1j * rng.random((*batch_shape, n, n))
+
+    A = (A + A.conj().swapaxes(-1, -2)) / 2
+
+    if compute_module == "cupy":
+        A = get_device(A)
+
+    w = eigvalsh(A, compute_module=compute_module, output_module=output_module)
+
+    assert w.shape[:-1] == batch_shape
+
+    assert w.shape[-1] == n
+
+    # check residual on the host
+    w = get_host(w)
+    A = get_host(A)
+
+    w_ref = np.linalg.eigvalsh(A)
+
+    w = np.sort(w)
+    w_ref = np.sort(w_ref)
+
+    assert xp.allclose(w, w_ref)
+
+
+@pytest.mark.usefixtures("n", "compute_module", "input_module", "output_module")
+def test_eigvalsh_generalized(
+    n: int, compute_module: str, input_module: str, output_module: str
+):
+    """Tests the eig function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+
+    rng = np.random.default_rng()
+
+    A = rng.random((n, n)) + 1j * rng.random((n, n))
+    B = rng.random((n, n)) + 1j * rng.random((n, n))
+
+    A = (A + A.conj().swapaxes(-1, -2)) / 2
+
+    B = (B + B.conj().swapaxes(-1, -2)) / 2
+    B += n * np.eye(n)
+
+    if compute_module == "cupy":
+        B = get_device(B)
+        A = get_device(A)
+
+    w = eigvalsh(A, B=B, compute_module=compute_module, output_module=output_module)
+
+    # check residual on the host
+    w = get_host(w)
+    A = get_host(A)
+    B = get_host(B)
+
+    w_ref = scipy.linalg.eigvalsh(A, b=B)
+
+    w = np.sort(w)
+    w_ref = np.sort(w_ref)
+
+    assert xp.allclose(w, w_ref)
+
+
+@pytest.mark.usefixtures(
+    "n", "batch_shape", "compute_module", "input_module", "output_module"
+)
+def test_eigvalsh_generalized_batched(
+    n: int,
+    batch_shape: tuple[int, ...],
+    compute_module: str,
+    input_module: str,
+    output_module: str,
+):
+    """Tests the eig function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+
+    rng = np.random.default_rng()
+
+    A = rng.random((*batch_shape, n, n)) + 1j * rng.random((*batch_shape, n, n))
+    B = rng.random((*batch_shape, n, n)) + 1j * rng.random((*batch_shape, n, n))
+
+    A = (A + A.conj().swapaxes(-1, -2)) / 2
+
+    B = (B + B.conj().swapaxes(-1, -2)) / 2
+    # need to be positive definite
+    # loop over batch dimensions
+
+    B = B.reshape((np.prod(batch_shape), n, n))
+    for i in range(np.prod(batch_shape)):
+        B[i] += n * np.eye(n)
+
+    B = B.reshape((*batch_shape, n, n))
+
+    if compute_module == "cupy":
+        B = get_device(B)
+        A = get_device(A)
+
+    w = eigvalsh(A, B=B, compute_module=compute_module, output_module=output_module)
+
+    assert w.shape[:-1] == batch_shape
+
+    assert w.shape[-1] == n
+
+    # check residual on the host
+    w = get_host(w)
+    A = get_host(A)
+    B = get_host(B)
+
+    w_ref = np.zeros_like(w)
+    w_ref = w_ref.reshape((np.prod(batch_shape), n))
+
+    A = A.reshape((np.prod(batch_shape), n, n))
+    B = B.reshape((np.prod(batch_shape), n, n))
+
+    for i in range(np.prod(batch_shape)):
+        w_ref[i] = scipy.linalg.eigvalsh(A[i], b=B[i])
+
+    w_ref = w_ref.reshape((*batch_shape, n))
+
+    w = np.sort(w, axis=-1)
+    w_ref = np.sort(w_ref, axis=-1)
+
+    assert xp.allclose(w, w_ref)

--- a/tests/kernels/test_operator.py
+++ b/tests/kernels/test_operator.py
@@ -8,13 +8,13 @@ from qttools.kernels.operator import operator_inverse
 
 @pytest.mark.usefixtures(
     "batchsize",
-    "blocksize",
+    "matrix_size",
     "num_quatrature_points",
     "num_blocks",
 )
 def test_operator_inverse(
     batchsize,
-    blocksize,
+    matrix_size,
     num_quatrature_points,
     num_blocks,
 ):
@@ -23,8 +23,8 @@ def test_operator_inverse(
 
     # mirror shape change inside beyn
     a_xx = tuple(
-        rng.random((batchsize, 1, blocksize, blocksize), dtype=xp.float64)
-        + 1j * rng.random((batchsize, 1, blocksize, blocksize), dtype=xp.float64)
+        rng.random((batchsize, 1, matrix_size, matrix_size), dtype=xp.float64)
+        + 1j * rng.random((batchsize, 1, matrix_size, matrix_size), dtype=xp.float64)
         for _ in range(2 * num_blocks + 1)
     )
 

--- a/tests/kernels/test_operator.py
+++ b/tests/kernels/test_operator.py
@@ -8,13 +8,13 @@ from qttools.kernels.operator import operator_inverse
 
 @pytest.mark.usefixtures(
     "batchsize",
-    "matrix_size",
+    "n",
     "num_quatrature_points",
     "num_blocks",
 )
 def test_operator_inverse(
     batchsize,
-    matrix_size,
+    n,
     num_quatrature_points,
     num_blocks,
 ):
@@ -23,8 +23,8 @@ def test_operator_inverse(
 
     # mirror shape change inside beyn
     a_xx = tuple(
-        rng.random((batchsize, 1, matrix_size, matrix_size), dtype=xp.float64)
-        + 1j * rng.random((batchsize, 1, matrix_size, matrix_size), dtype=xp.float64)
+        rng.random((batchsize, 1, n, n), dtype=xp.float64)
+        + 1j * rng.random((batchsize, 1, n, n), dtype=xp.float64)
         for _ in range(2 * num_blocks + 1)
     )
 

--- a/tests/kernels/test_svd.py
+++ b/tests/kernels/test_svd.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+
+from qttools import xp
+from qttools.kernels.svd import svd
+from qttools.utils.gpu_utils import get_host
+
+if xp.__name__ == "cupy":
+    import cupy as cp
+
+
+@pytest.mark.usefixtures(
+    "m", "n", "full_matrices", "compute_module", "input_module", "output_module"
+)
+def test_svd(
+    m: int,
+    n: int,
+    full_matrices: bool,
+    compute_module: str,
+    input_module: str,
+    output_module: str,
+):
+    """Tests the svd function."""
+
+    if xp.__name__ == "numpy" and (
+        compute_module == "cupy" or output_module == "cupy" or input_module == "cupy"
+    ):
+        return
+
+    if input_module == "cupy":
+        rng = cp.random.default_rng()
+    elif input_module == "numpy":
+        rng = np.random.default_rng()
+
+    A = rng.random((m, n)) + 1j * rng.random((m, n))
+
+    u, s, vh = svd(
+        A,
+        compute_module=compute_module,
+        output_module=output_module,
+        full_matrices=full_matrices,
+    )
+
+    # check residual on the host
+    u = get_host(u)
+    s = get_host(s)
+    vh = get_host(vh)
+    A = get_host(A)
+
+    if full_matrices:
+        k = min(m, n)
+        u = u[:, :k]
+        s = s[:k]
+        vh = vh[:k, :]
+
+    assert xp.allclose(A, u @ np.diag(s) @ vh)


### PR DESCRIPTION
This enables that the eigen decompositions can done on the GPU
if cupy.linalg.eig is available. 

This is only beneficial for large enough matrix sizes.
Thus, the user should have the option to disable it.

The code leads to a ValueError if "device" was selected, but cp.linalg.eig is unavailable.
If "device" is selected and eig is available, but the runtime is hip, then cupy will throw an error.
The logic could be changed not to throw errors but to give warnings.


- [x] Beyn OBC
- [x] Spectral Lyapunov
- [x] Linearized OBC

The following extension should be done for better performance with different input sizes:
- [x] Allow input and output location
- [x] Same extension for SVD
- [x] Host eig with numba loop for the batch
- [x] Generalized Eighvalsh on the GPU 
 