### PR TITLE
Fix for comparison with `slice(None)`

### DIFF
--- a/src/qttools/datastructures/dsbcoo.py
+++ b/src/qttools/datastructures/dsbcoo.py
@@ -257,7 +257,7 @@ class DSBCOO(DSBSparse):
         block_slice = self._get_block_slice(row, col)
 
         if not self.return_dense:
-            if block_slice == slice(None):
+            if block_slice.start is None and block_slice.stop is None:
                 # No data in this block, return an empty block.
                 return xp.empty(0), xp.empty(0), xp.empty(data_stack.shape[:-1] + (0,))
 
@@ -270,7 +270,7 @@ class DSBCOO(DSBSparse):
             + (int(self.block_sizes[row]), int(self.block_sizes[col])),
             dtype=self.dtype,
         )
-        if block_slice == slice(None):
+        if block_slice.start is None and block_slice.stop is None:
             # No data in this block, return an empty block.
             return block
 
@@ -304,7 +304,7 @@ class DSBCOO(DSBSparse):
 
         """
         block_slice = self._get_block_slice(row, col)
-        if block_slice == slice(None):
+        if block_slice.start is None and block_slice.stop is None:
             # No data in this block, nothing to do.
             return
 


### PR DESCRIPTION
This PR amends the comparison of block slices with `slice(None)` in the DSBCOO Datastructure to work with newer Python/CuPy versions.