### PR TITLE
Smaller batch size for contour integral

### DIFF
--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -50,7 +50,8 @@ class Beyn(NEVP):
         Whether to use QR decomposition for the projector instead of SVD.
         Default is `False`.
     contour_batch_size : int, optional
-        The batch size for the contour integration kernel.
+        The batch size for the contour integration kernel. If `None`,
+        the batch size is set to `num_quad_points`.
 
     """
 
@@ -64,7 +65,7 @@ class Beyn(NEVP):
         eig_compute_location: str = "numpy",
         project_compute_location: str = "numpy",
         use_qr: bool = False,
-        contour_batch_size: int = 10,
+        contour_batch_size: int | None = None,
     ):
         """Initializes the Beyn NEVP solver."""
         self.r_o = r_o
@@ -75,6 +76,9 @@ class Beyn(NEVP):
         self.eig_compute_location = eig_compute_location
         self.project_compute_location = project_compute_location
         self.use_qr = use_qr
+        if contour_batch_size is None:
+            contour_batch_size = num_quad_points
+
         self.contour_batch_size = contour_batch_size
 
         contour_counts, _ = get_section_sizes(
@@ -183,7 +187,7 @@ class Beyn(NEVP):
         else:
             return a, q
 
-    def _contour_integrate(self, a_xx: tuple[NDArray, ...]):
+    def _contour_integrate(self, a_xx: tuple[NDArray, ...]) -> tuple[NDArray, NDArray]:
         """Computes the contour integral of the operator inverse.
 
         Parameters

--- a/src/qttools/nevp/beyn.py
+++ b/src/qttools/nevp/beyn.py
@@ -8,6 +8,7 @@ from qttools import NDArray, xp
 from qttools.kernels import linalg
 from qttools.kernels.operator import operator_inverse
 from qttools.nevp.nevp import NEVP
+from qttools.utils.mpi_utils import get_section_sizes
 
 rng = xp.random.default_rng(42)
 
@@ -76,14 +77,9 @@ class Beyn(NEVP):
         self.use_qr = use_qr
         self.contour_batch_size = contour_batch_size
 
-        if num_quad_points > contour_batch_size:
-            contour_counts = [
-                contour_batch_size for _ in range(num_quad_points // contour_batch_size)
-            ]
-            for i in range(num_quad_points % contour_batch_size):
-                contour_counts[i % len(contour_counts)] += 1
-        else:
-            contour_counts = [num_quad_points]
+        contour_counts, _ = get_section_sizes(
+            num_quad_points, int(np.ceil(num_quad_points / contour_batch_size))
+        )
 
         self.contour_displacements = np.cumsum(
             np.concatenate(([0], np.array(contour_counts)))

--- a/src/qttools/obc/spectral.py
+++ b/src/qttools/obc/spectral.py
@@ -342,7 +342,7 @@ class Spectral(OBCSolver):
             if self.residual_normalization == "eigenvalue":
                 residuals /= xp.abs(ws)
 
-        if batchsize != 1 and find_injected == True:
+        if batchsize != 1 and find_injected:
             raise ValueError(
                 "The injection vector can only be calculated with batchsize = 1"
             )
@@ -598,19 +598,24 @@ class Spectral(OBCSolver):
         Returns
         -------
         x_ii : NDArray
-            The system's surface Green's function. 
+            The system's surface Green's function.
         sigma_retarded: NDArray
-            The boundary self energy. Returned only if return_injected == True. (only compatible with batchsize = 1)
+            The boundary self energy. Returned only if return_injected
+            is True. (only compatible with batchsize = 1)
         inj: NDArray
-            The Injection vector. Returned only if return_injected == True. (only compatible with batchsize = 1)
+            The Injection vector. Returned only if return_injected is
+            True. (only compatible with batchsize = 1)
         w_inj: NDArray
-            The eigenvalues of the injected modes. Returned only if return_injected == True. (only compatible with batchsize = 1)
+            The eigenvalues of the injected modes. Returned only if
+            return_injected is True. (only compatible with batchsize =
+            1)
+
         """
 
-        if a_ii.ndim != 2 and return_injected == True:
+        if a_ii.ndim != 2 and return_injected:
             raise NotImplementedError
 
-        if return_injected == True and out is not None:
+        if return_injected and out is not None:
             raise NotImplementedError
 
         if a_ii.ndim == 2:
@@ -632,7 +637,11 @@ class Spectral(OBCSolver):
 
         if return_injected:
             mask_reflected, mask_injected, dE_dK_injected = self._find_reflected_modes(
-                wrs, vrs, a_xx=(a_ji, a_ii, a_ij), vls=vls, find_injected=return_injected
+                wrs,
+                vrs,
+                a_xx=(a_ji, a_ii, a_ij),
+                vls=vls,
+                find_injected=return_injected,
             )
         else:
             mask_reflected = self._find_reflected_modes(
@@ -672,7 +681,10 @@ class Spectral(OBCSolver):
             sigma_retarded = a_ji[0, :, :] @ x_ii[0, :, :] @ a_ij[0, :, :]
 
             # Compute injection vector
-            injection = -a_ji[0, :, :] @ vrs_inj @ xp.linalg.inv(wrs_inj) - sigma_retarded @ vrs_inj
+            injection = (
+                -a_ji[0, :, :] @ vrs_inj @ xp.linalg.inv(wrs_inj)
+                - sigma_retarded @ vrs_inj
+            )
 
             return x_ii_ref, sigma_retarded, injection, wrs[0, mask_injected]
 

--- a/tests/nevp/conftest.py
+++ b/tests/nevp/conftest.py
@@ -16,15 +16,34 @@ BLOCK_SIZE = [
 # capture all the eigenvalues. The number of quadrature points is set to
 # a very large number to ensure that the non-spurious eigenvalues get
 # approximated very accurately.
-SUBSPACE_NEVP_SOLVERS = [
-    pytest.param(
-        Beyn(r_o=1.2, r_i=0.9, m_0=60, num_quad_points=200, use_qr=False), id="Beyn"
-    ),
-    pytest.param(
-        Beyn(r_o=1.2, r_i=0.9, m_0=60, num_quad_points=200, use_qr=True),
-        id="Beyn with QR",
-    ),
+BATCH_SIZES = [
+    2,
+    25,
+    30,
 ]
+
+SUBSPACE_NEVP_SOLVERS = []
+
+for BATCH_SIZE in BATCH_SIZES:
+    for use_qr in [
+        False,
+        True,
+    ]:
+        SUBSPACE_NEVP_SOLVERS.append(
+            pytest.param(
+                Beyn(
+                    r_o=1.2,
+                    r_i=0.9,
+                    m_0=60,
+                    num_quad_points=200,
+                    use_qr=use_qr,
+                    contour_batch_size=BATCH_SIZE,
+                ),
+                id=f"Beyn with QR batch size {BATCH_SIZE} and use_qr {use_qr}",
+            )
+        )
+
+
 LEFT = [pytest.param(True, id="both"), pytest.param(False, id="right")]
 
 

--- a/tests/nevp/conftest.py
+++ b/tests/nevp/conftest.py
@@ -16,11 +16,7 @@ BLOCK_SIZE = [
 # capture all the eigenvalues. The number of quadrature points is set to
 # a very large number to ensure that the non-spurious eigenvalues get
 # approximated very accurately.
-BATCH_SIZES = [
-    2,
-    25,
-    30,
-]
+BATCH_SIZES = [2, 25, 30]
 
 SUBSPACE_NEVP_SOLVERS = []
 

--- a/tests/obc/conftest.py
+++ b/tests/obc/conftest.py
@@ -12,33 +12,15 @@ from qttools.nevp import NEVP, Beyn, Full
 # large to capture all the eigenvalues in that annulus. The number of
 # quadrature points is set such that non-spurious eigenvalues get
 # approximated accurately enough.
-BATCH_SIZES = [
-    2,
-    14,
-]
-
 NEVP_SOLVERS = [
+    pytest.param(
+        Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13, use_qr=False), id="Beyn"
+    ),
+    pytest.param(
+        Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13, use_qr=True), id="Beyn"
+    ),
     pytest.param(Full(), id="Full"),
 ]
-
-for BATCH_SIZE in BATCH_SIZES:
-    for use_qr in [
-        False,
-        True,
-    ]:
-        NEVP_SOLVERS.append(
-            pytest.param(
-                Beyn(
-                    r_o=200,
-                    r_i=0.9,
-                    m_0=23,
-                    num_quad_points=13,
-                    use_qr=use_qr,
-                    contour_batch_size=BATCH_SIZE,
-                ),
-                id=f"Beyn with QR batch size {BATCH_SIZE} and use_qr {use_qr}",
-            )
-        )
 
 X_II_FORMULAS = ["self-energy", "direct"]
 

--- a/tests/obc/conftest.py
+++ b/tests/obc/conftest.py
@@ -12,15 +12,33 @@ from qttools.nevp import NEVP, Beyn, Full
 # large to capture all the eigenvalues in that annulus. The number of
 # quadrature points is set such that non-spurious eigenvalues get
 # approximated accurately enough.
+BATCH_SIZES = [
+    2,
+    14,
+]
+
 NEVP_SOLVERS = [
-    pytest.param(
-        Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13, use_qr=False), id="Beyn"
-    ),
-    pytest.param(
-        Beyn(r_o=200, r_i=0.9, m_0=23, num_quad_points=13, use_qr=True), id="Beyn"
-    ),
     pytest.param(Full(), id="Full"),
 ]
+
+for BATCH_SIZE in BATCH_SIZES:
+    for use_qr in [
+        False,
+        True,
+    ]:
+        NEVP_SOLVERS.append(
+            pytest.param(
+                Beyn(
+                    r_o=200,
+                    r_i=0.9,
+                    m_0=23,
+                    num_quad_points=13,
+                    use_qr=use_qr,
+                    contour_batch_size=BATCH_SIZE,
+                ),
+                id=f"Beyn with QR batch size {BATCH_SIZE} and use_qr {use_qr}",
+            )
+        )
 
 X_II_FORMULAS = ["self-energy", "direct"]
 

--- a/tests/obc/test_spectral.py
+++ b/tests/obc/test_spectral.py
@@ -227,6 +227,6 @@ def test_compute_dE_dk(
                 phi_right = vrs[i, :, j]
                 phi_left = vrs[i, :, j]
 
-            dEk_dk_ref[i, j] = (phi_left.conj().T @ a @ phi_right) 
+            dEk_dk_ref[i, j] = phi_left.conj().T @ a @ phi_right
 
     assert xp.allclose(dEk_dk, dEk_dk_ref)


### PR DESCRIPTION
Limits the batch size used for the contour integral.

If one batches over all the contour points, then this leads to a memory peak
which can lead to OOM.