### PR TITLE
System reduction for Lyapunov

### DIFF
--- a/src/qttools/lyapunov/utils.py
+++ b/src/qttools/lyapunov/utils.py
@@ -1,6 +1,92 @@
 from qttools import NDArray, xp
 
 
+def _system_reduction_rows(
+    a: NDArray,
+    q: NDArray,
+    solve,
+    row_start,
+    row_end,
+):
+    """Reduces the system by rows of A that are all zero.
+
+    Parameters
+    ----------
+    a : NDArray
+        The system matrix.
+    q : NDArray
+        The right-hand side matrix.
+    solve : function
+        The solver to use for the reduced system.
+    row_start : int
+        The first row with non-zero elements.
+    row_end : int
+        The last row with non-zero elements.
+
+    Returns
+    -------
+    x : NDArray
+        The solution of the reduced system.
+
+    """
+
+    a_hat = a[:, row_start:row_end, row_start:row_end]
+
+    x = q.copy()
+    x[:, row_start:row_end, row_start:row_end] = 0
+    q_hat = q[:, row_start:row_end, row_start:row_end] + (
+        a[:, row_start:row_end, :]
+        @ x
+        @ a[:, row_start:row_end, :].conj().swapaxes(-2, -1)
+    )
+
+    x[:, row_start:row_end, row_start:row_end] = solve(a_hat, q_hat)
+
+    return x
+
+
+def _system_reduction_cols(
+    a: NDArray,
+    q: NDArray,
+    solve,
+    col_start,
+    col_end,
+):
+    """Reduces the system by columns of A that are all zero.
+
+    Parameters
+    ----------
+    a : NDArray
+        The system matrix.
+    q : NDArray
+        The right-hand side matrix.
+    solve : function
+        The solver to use for the reduced system.
+    col_start : int
+        The first column with non-zero elements.
+    col_end : int
+        The last column with non-zero elements.
+
+    Returns
+    -------
+    x : NDArray
+        The solution of the reduced system.
+
+    """
+
+    a_hat = a[:, col_start:col_end, col_start:col_end]
+
+    q_hat = q[:, col_start:col_end, col_start:col_end]
+
+    x_hat = solve(a_hat, q_hat)
+
+    x = q.copy() + a[:, :, col_start:col_end] @ x_hat @ a[
+        :, :, col_start:col_end
+    ].conj().swapaxes(-2, -1)
+
+    return x
+
+
 def system_reduction(
     a: NDArray,
     q: NDArray,
@@ -45,31 +131,40 @@ def system_reduction(
         a = a[xp.newaxis, ...]
         q = q[xp.newaxis, ...]
 
-    # NOTE: possible to further reduce
-    # but it is assumed contiguous rows are non-zero
+    # get first and last row/cols with non-zero elements
+    nnz_rows = xp.sum(xp.abs(a), axis=-1) > 0
+    nnz_cols = xp.sum(xp.abs(a), axis=-2) > 0
 
-    # get first row with non-zero elements
-    row_start = xp.argmax(xp.sum(xp.abs(a), axis=-1) > 0, axis=-1)
-    # get last row with non-zero elements
-    row_end = a.shape[-1] - xp.argmax(xp.sum(xp.abs(a), axis=-1)[:, ::-1] > 0, axis=-1)
+    row_start = xp.argmax(nnz_rows, axis=-1)
+    row_end = a.shape[-1] - xp.argmax(nnz_rows[:, ::-1], axis=-1)
 
-    # assumes same sparsity pattern for all matrices
-    assert xp.all(row_start == row_start[0])
-    assert xp.all(row_end == row_end[0])
-    row_start = row_start[0]
-    row_end = row_end[0]
+    col_start = xp.argmax(nnz_cols, axis=-1)
+    col_end = a.shape[-2] - xp.argmax(nnz_cols[:, ::-1], axis=-1)
 
-    a_hat = a[:, row_start:row_end, row_start:row_end]
+    any_rows = xp.any(nnz_rows, axis=-1)
+    any_cols = xp.any(nnz_cols, axis=-1)
 
-    x = q.copy()
-    x[:, row_start:row_end, row_start:row_end] = 0
-    q_hat = q[:, row_start:row_end, row_start:row_end] + (
-        a[:, row_start:row_end, :]
-        @ x
-        @ a[:, row_start:row_end, :].conj().swapaxes(-2, -1)
-    )
+    # account for only zero rows/cols
+    # else will not reduce
+    row_start = xp.min(row_start[any_rows])
+    row_end = xp.max(row_end[any_rows])
+    col_start = xp.min(col_start[any_cols])
+    col_end = xp.max(col_end[any_cols])
 
-    x[:, row_start:row_end, row_start:row_end] = solve(a_hat, q_hat)
+    length_row = row_end - row_start
+    length_col = col_end - col_start
+
+    # only reduce in either rows or cols
+    # TODO: reduce in both directions
+    # but not occuring in the current use case
+    # Would be calling reduce cols inside reduce rows
+    # or reduce rows inside reduce cols
+    # Furthermore, possible to reduce to non contiguous rows/cols
+
+    if length_row < length_col:
+        x = _system_reduction_rows(a, q, solve, row_start, row_end)
+    else:
+        x = _system_reduction_cols(a, q, solve, col_start, col_end)
 
     x = x.reshape(*batch_shape, *x.shape[-2:])
 

--- a/tests/lyapunov/test_lyapunov.py
+++ b/tests/lyapunov/test_lyapunov.py
@@ -56,17 +56,43 @@ def test_reduced_system(
     if hasattr(lyapunov_solver, "reduce_sparsity"):
         lyapunov_solver.reduce_sparsity = True
 
-    for _ in range(1, 5):
-        row_start = 1 + np.random.randint(0, a.shape[-1] - 1)
+    row_start = 1 + np.random.randint(0, a.shape[-1] - 1)
+    row_end = max(
+        row_start + 1 + np.random.randint(0, max(a.shape[-1] - row_start - 1, 1)),
+        a.shape[-1] - 1,
+    )
 
-        row_end = a.shape[-1] - np.random.randint(0, a.shape[-1] - row_start)
+    col_start = 1 + np.random.randint(0, a.shape[-1] - 1)
+    col_end = max(
+        col_start + 1 + np.random.randint(0, max(a.shape[-1] - col_start - 1, 1)),
+        a.shape[-1] - 1,
+    )
 
-        a[:, :row_start] = 0
-        a[:, row_end:] = 0
+    a_cpy = a.copy()
+    a_cpy[:row_start, :] = 0
+    a_cpy[row_end:, :] = 0
 
-        x = lyapunov_solver(a, q, "contact")
+    x = lyapunov_solver(a_cpy, q, "contact")
 
-        assert xp.allclose(x, a @ x @ a.conj().swapaxes(-1, -2) + q)
+    assert xp.allclose(x, a_cpy @ x @ a_cpy.conj().swapaxes(-1, -2) + q)
+
+    a_cpy = a.copy()
+    a_cpy[:, :col_start] = 0
+    a_cpy[:, col_end:] = 0
+
+    x = lyapunov_solver(a_cpy, q, "contact")
+
+    assert xp.allclose(x, a_cpy @ x @ a_cpy.conj().swapaxes(-1, -2) + q)
+
+    a_cpy = a.copy()
+    a_cpy[:row_start, :] = 0
+    a_cpy[row_end:, :] = 0
+    a_cpy[:, :col_start] = 0
+    a_cpy[:, col_end:] = 0
+
+    x = lyapunov_solver(a_cpy, q, "contact")
+
+    assert xp.allclose(x, a_cpy @ x @ a_cpy.conj().swapaxes(-1, -2) + q)
 
     if hasattr(lyapunov_solver, "reduce_sparsity"):
         lyapunov_solver.reduce_sparsity = False
@@ -85,20 +111,46 @@ def test_reduced_system_batch(
     if hasattr(lyapunov_solver, "reduce_sparsity"):
         lyapunov_solver.reduce_sparsity = True
 
-    for i in range(1, 5):
-        row_start = 1 + np.random.randint(0, a.shape[-1] - 1)
+    row_start = 1 + np.random.randint(0, a.shape[-1] - 1)
+    row_end = max(
+        row_start + 1 + np.random.randint(0, max(a.shape[-1] - row_start - 1, 1)),
+        a.shape[-1] - 1,
+    )
 
-        row_end = a.shape[-1] - np.random.randint(0, a.shape[-1] - row_start)
+    col_start = 1 + np.random.randint(0, a.shape[-1] - 1)
+    col_end = max(
+        col_start + 1 + np.random.randint(0, max(a.shape[-1] - col_start - 1, 1)),
+        a.shape[-1] - 1,
+    )
 
-        a[:, :row_start] = 0
-        a[:, row_end:] = 0
+    a = xp.stack([a for __ in range(10)])
+    q = xp.stack([q for __ in range(10)])
 
-        a = xp.stack([a for __ in range(i)])
-        q = xp.stack([q for __ in range(i)])
+    a_cpy = a.copy()
+    a_cpy[:, :row_start, :] = 0
+    a_cpy[:, row_end:, :] = 0
 
-        x = lyapunov_solver(a, q, "contact")
+    x = lyapunov_solver(a_cpy, q, "contact")
 
-        assert xp.allclose(x, a @ x @ a.conj().swapaxes(-1, -2) + q)
+    assert xp.allclose(x, a_cpy @ x @ a_cpy.conj().swapaxes(-1, -2) + q)
+
+    a_cpy = a.copy()
+    a_cpy[:, :, :col_start] = 0
+    a_cpy[:, :, col_end:] = 0
+
+    x = lyapunov_solver(a_cpy, q, "contact")
+
+    assert xp.allclose(x, a_cpy @ x @ a_cpy.conj().swapaxes(-1, -2) + q)
+
+    a_cpy = a.copy()
+    a_cpy[:, :row_start, :] = 0
+    a_cpy[:, row_end:, :] = 0
+    a_cpy[:, :, :col_start] = 0
+    a_cpy[:, :, col_end:] = 0
+
+    x = lyapunov_solver(a_cpy, q, "contact")
+
+    assert xp.allclose(x, a_cpy @ x @ a_cpy.conj().swapaxes(-1, -2) + q)
 
     if hasattr(lyapunov_solver, "reduce_sparsity"):
         lyapunov_solver.reduce_sparsity = False


### PR DESCRIPTION
Reduces the Lyapunov system with testing for many
zero rows or columns.

Reductions in both dimensions are not supported.
This case should also not occur in GW.

Notes about system reduction for discrete Lyapunov:
$$A X A^H - X + Q = 0$$
- if $A$ has only certain rows with nonzero elements,
the system can be reduced to a smaller problem of (#nz rows x #nz rows)
$$B X_{nz,nz} B^H - X_{nz,nz} + K = 0$$
where
$$B = A_{nz,nz} $$
$$K = Q_{nz,nz} + A_{nz,:} (Q  - Q_{nz,nz} ) A_{nz,:}^H$$
The total solution is then
$$X =  (Q  - Q_{nz,nz} ) + X_{nz,nz} $$

- if $A$ has only certain columns with nonzero elements,
the system can be reduced to a smaller problem of (#nz cols x #nz cols )
$$B X_{nz,nz} B^H - X_{nz,nz} + K = 0$$
$$B = A_{nz,nz} $$
$$K = Q_{nz,nz}$$
The total solution is then
$$X =  Q + A_{:,nz} X_{nz,nz} A_{:,nz}^H$$

(Terms in the form $Y  \pm Z_{nz,nz}$ mean that $Z$ operates only on the rows/columns of $Y$
corresponding to the nonzero rows of $A$)
