### PR TITLE
DSBSparse.dtranspose does also local transpose.

### DIFF
--- a/src/qttools/datastructures/dsbcoo.py
+++ b/src/qttools/datastructures/dsbcoo.py
@@ -190,12 +190,13 @@ class DSBCOO(DSBSparse):
         # We need to access the full data buffer directly to set the
         # value since we are using advanced indexing.
         if value.ndim == 0:
-            self._data[stack_inds, stack_index[1:] or Ellipsis, nnz_inds] = value
+            self._data[nnz_inds, stack_inds, stack_index[1:] or Ellipsis] = value
             return
 
-        self._data[stack_inds, stack_index[1:] or Ellipsis, nnz_inds] = value[
-            ..., value_inds[ranks == comm.rank] - value_inds[ranks == comm.rank][0]
-        ]
+        indices = tuple(range(len(value.shape) - 1))
+        self._data[nnz_inds, stack_inds, stack_index[1:] or Ellipsis] = value[
+            value_inds[ranks == comm.rank] - value_inds[ranks == comm.rank][0], ...
+        ].transpose((-1, *indices))
         return
 
     @profiler.profile(level="debug")

--- a/src/qttools/datastructures/dsbcsr.py
+++ b/src/qttools/datastructures/dsbcsr.py
@@ -172,12 +172,13 @@ class DSBCSR(DSBSparse):
         # We need to access the full data buffer directly to set the
         # value since we are using advanced indexing.
         if value.ndim == 0:
-            self._data[stack_inds, stack_index[1:] or Ellipsis, nnz_inds] = value
+            self._data[nnz_inds, stack_inds, stack_index[1:] or Ellipsis] = value
             return
 
-        self._data[stack_inds, stack_index[1:] or Ellipsis, nnz_inds] = value[
+        indices = tuple(range(len(value.shape) - 1))
+        self._data[nnz_inds, stack_inds, stack_index[1:] or Ellipsis] = value[
             ..., value_inds[ranks == comm.rank] - value_inds[ranks == comm.rank][0]
-        ]
+        ].transpose((-1, *indices))
         return
 
     @profiler.profile(level="debug")


### PR DESCRIPTION
This PR makes it so that when the datastructure is in the "nnz" state, the first dimension has the local nnz/interactions instead of the global stack/energies.