### PR TITLE
Revomed sync for memoization

### DIFF
--- a/src/qttools/lyapunov/lyapunov.py
+++ b/src/qttools/lyapunov/lyapunov.py
@@ -16,7 +16,6 @@ from qttools import (
 )
 from qttools.lyapunov.utils import system_reduction
 from qttools.profiling import Profiler
-from qttools.utils.gpu_utils import get_device, get_host, synchronize_current_stream
 from qttools.utils.mpi_utils import check_gpu_aware_mpi
 
 profiler = Profiler()
@@ -203,38 +202,12 @@ class LyapunovMemoizer:
                 x_ref, axis=(-2, -1)
             )
 
-            local_memoizing = xp.array(
-                xp.all(
-                    (absolute_recursion_errors < self.memoize_abs_tol)
-                    | (relative_recursion_errors < self.memoize_rel_tol)
-                ),
-                dtype=int,
+            local_memoizing = xp.all(
+                (absolute_recursion_errors < self.memoize_abs_tol)
+                | (relative_recursion_errors < self.memoize_rel_tol)
             )
-            memoizing = xp.empty_like(local_memoizing)
 
-            # NCCL allreduce does not support op="and"
-            synchronize_current_stream()
-            # NCCL allreduce does not support op="and"
-            if NCCL_AVAILABLE:
-                nccl_comm.all_reduce(local_memoizing, memoizing, op="sum")
-            elif GPU_AWARE_MPI:
-                comm.Allreduce(local_memoizing, memoizing, op=MPI.SUM)
-            else:
-                local_memoizing = get_host(local_memoizing)
-                # TODO: this memcopy is not necessary
-                # but for consistency with the other cases
-                memoizing = get_host(memoizing)
-                comm.Allreduce(local_memoizing, memoizing, op=MPI.SUM)
-                memoizing = get_device(memoizing)
-            synchronize_current_stream()
-
-            if comm.rank == 0:
-                print(
-                    f"{memoizing} out of {comm.size} ranks want to memoize {contact} Lyapunov",
-                    flush=True,
-                )
-
-            if memoizing != comm.size:
+            if local_memoizing:
                 # If the result did not converge, recompute it from scratch.
                 return self._call_with_cache(a, q, contact, out=out)
 

--- a/src/qttools/lyapunov/lyapunov.py
+++ b/src/qttools/lyapunov/lyapunov.py
@@ -3,17 +3,7 @@
 import warnings
 from abc import ABC, abstractmethod
 
-from mpi4py import MPI
-
-from qttools import (
-    NCCL_AVAILABLE,
-    NDArray,
-    global_comm,
-    nccl_comm,
-    nccl_stack_comm,
-    stack_comm,
-    xp,
-)
+from qttools import NDArray, global_comm, stack_comm, xp
 from qttools.lyapunov.utils import system_reduction
 from qttools.profiling import Profiler
 from qttools.utils.mpi_utils import check_gpu_aware_mpi
@@ -22,7 +12,6 @@ profiler = Profiler()
 
 GPU_AWARE_MPI = check_gpu_aware_mpi()
 comm = global_comm if stack_comm is None else stack_comm
-nccl_comm = nccl_comm if nccl_stack_comm is None else nccl_stack_comm
 
 
 class LyapunovSolver(ABC):

--- a/src/qttools/lyapunov/lyapunov.py
+++ b/src/qttools/lyapunov/lyapunov.py
@@ -207,7 +207,7 @@ class LyapunovMemoizer:
                 | (relative_recursion_errors < self.memoize_rel_tol)
             )
 
-            if local_memoizing:
+            if not local_memoizing:
                 # If the result did not converge, recompute it from scratch.
                 return self._call_with_cache(a, q, contact, out=out)
 

--- a/src/qttools/obc/obc.py
+++ b/src/qttools/obc/obc.py
@@ -3,17 +3,7 @@
 import warnings
 from abc import ABC, abstractmethod
 
-from mpi4py import MPI
-
-from qttools import (
-    NCCL_AVAILABLE,
-    NDArray,
-    global_comm,
-    nccl_comm,
-    nccl_stack_comm,
-    stack_comm,
-    xp,
-)
+from qttools import NDArray, global_comm, stack_comm, xp
 from qttools.kernels.linalg import inv
 from qttools.profiling import Profiler
 from qttools.utils.mpi_utils import check_gpu_aware_mpi
@@ -22,7 +12,6 @@ profiler = Profiler()
 
 GPU_AWARE_MPI = check_gpu_aware_mpi()
 comm = global_comm if stack_comm is None else stack_comm
-nccl_comm = nccl_comm if nccl_stack_comm is None else nccl_stack_comm
 
 
 class OBCSolver(ABC):

--- a/src/qttools/obc/obc.py
+++ b/src/qttools/obc/obc.py
@@ -213,7 +213,7 @@ class OBCMemoizer:
             )
 
             # NOTE: it would be possible to memoize even if few energies did not converge
-            if local_memoizing:
+            if not local_memoizing:
                 # If the result did not converge, recompute it from scratch.
                 return self._call_with_cache(a_ii, a_ij, a_ji, contact, out=out)
 


### PR DESCRIPTION
The allreduce in the memoizers can cause deadlocks if system reduction is on.
This happens because the system reduction early exists before solving if the input A is zero.

We should refactor the system reduction and the memoizers later...